### PR TITLE
Declare MapperTransform.init to be public.

### DIFF
--- a/ObjectMapper/Transforms/MapperTransform.swift
+++ b/ObjectMapper/Transforms/MapperTransform.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class MapperTransform<ObjectType, JSONType> {
     
-    init(){
+    public init(){
     
     }
     


### PR DESCRIPTION
This fixes the following error when subclassing `MapperTransform` outside of ObjectMapper:

``` swift
public class ISO8601DateTransform<ObjectType, JSONType>: MapperTransform<ObjectType, JSONType> {
    let dateFormatter = NSDateFormatter()

    public override init() {
        dateFormatter.timeZone = NSTimeZone(name: "GMT")
        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"
        dateFormatter.locale = NSLocale(localeIdentifier: "en_US")
    }

    // rest of implementation here
}
```

```
Initializer does not override a designated initializer from its superclass
```
