### PR TITLE
ISO 8601 date transformer

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		6AAC8FD119F048FE00E7A677 /* ToJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC719F048FE00E7A677 /* ToJSON.swift */; };
 		6AAC8FD319F048FE00E7A677 /* DateTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FCB19F048FE00E7A677 /* DateTransform.swift */; };
 		6AAC8FD419F048FE00E7A677 /* MapperTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FCC19F048FE00E7A677 /* MapperTransform.swift */; };
+		D86BDEA41A51E5AD00120819 /* ISO8601DateTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86BDEA31A51E5AC00120819 /* ISO8601DateTransform.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +45,7 @@
 		6AAC8FC719F048FE00E7A677 /* ToJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToJSON.swift; sourceTree = "<group>"; };
 		6AAC8FCB19F048FE00E7A677 /* DateTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateTransform.swift; sourceTree = "<group>"; };
 		6AAC8FCC19F048FE00E7A677 /* MapperTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapperTransform.swift; sourceTree = "<group>"; };
+		D86BDEA31A51E5AC00120819 /* ISO8601DateTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ISO8601DateTransform.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -134,6 +136,7 @@
 			isa = PBXGroup;
 			children = (
 				6AAC8FCB19F048FE00E7A677 /* DateTransform.swift */,
+				D86BDEA31A51E5AC00120819 /* ISO8601DateTransform.swift */,
 				6A6C54CF19FE8DB600239454 /* URLTransform.swift */,
 				6AAC8FCC19F048FE00E7A677 /* MapperTransform.swift */,
 			);
@@ -248,6 +251,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6AAC8FD319F048FE00E7A677 /* DateTransform.swift in Sources */,
+				D86BDEA41A51E5AD00120819 /* ISO8601DateTransform.swift in Sources */,
 				6AAC8FD419F048FE00E7A677 /* MapperTransform.swift in Sources */,
 				6A6C54D019FE8DB600239454 /* URLTransform.swift in Sources */,
 				6AAC8FCE19F048FE00E7A677 /* Mapper.swift in Sources */,

--- a/ObjectMapper/Transforms/ISO8601DateTransform.swift
+++ b/ObjectMapper/Transforms/ISO8601DateTransform.swift
@@ -1,0 +1,35 @@
+//
+//  ISO8601DateTransform.swift
+//  ObjectMapper
+//
+//  Created by Jean-Pierre Mouilleseaux on 21 Nov 2014.
+//
+//
+
+import Foundation
+
+public class ISO8601DateTransform<ObjectType, JSONType>: MapperTransform<ObjectType, JSONType> {
+    public override init() {
+    }
+
+    func dateFormatter() -> NSDateFormatter {
+        let formatter = NSDateFormatter()
+        formatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        return formatter
+    }
+
+    override public func transformFromJSON(value: AnyObject?) -> ObjectType? {
+        if let dateString = value as? String {
+            return (dateFormatter().dateFromString(dateString) as ObjectType)
+        }
+        return nil
+    }
+
+    override public func transformToJSON(value: ObjectType?) -> JSONType? {
+        if let date = value as? NSDate {
+            return (dateFormatter().stringFromDate(date) as JSONType)
+        }
+        return nil
+    }
+}

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -33,18 +33,19 @@ class ObjectMapperTests: XCTestCase {
         let smoker = false
         let arr = [ "bla", true, 42 ]
         let birthday = NSDate(timeIntervalSince1970: 1398956159)
+        let y2k = NSDate(timeIntervalSince1970: 946684800) // calculated via http://wolfr.am/2pliY~W9
         let directory = [
             "key1" : "value1",
             "key2" : false,
             "key3" : 142
         ]
         
-        let subUserJSON = "{\"identifier\" : \"user8723\", \"drinker\" : true, \"age\": 17,\"birthdayOpt\" : 1398956159, \"username\" : \"sub user\" }"
+        let subUserJSON = "{\"identifier\" : \"user8723\", \"drinker\" : true, \"age\": 17, \"birthdayOpt\" : 1398956159, \"y2kOpt\" : \"2000-01-01T00:00:00Z\", \"username\" : \"sub user\" }"
         
-        let userJSONString = "{\"username\":\"\(username)\",\"identifier\":\"\(identifier)\",\"photoCount\":\(photoCount),\"age\":\(age),\"drinker\":\(drinker),\"smoker\":\(smoker), \"arr\":[ \"bla\", true, 42 ], \"dict\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"arrOpt\":[ \"bla\", true, 42 ], \"dictOpt\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"birthday\": 1398956159, \"birthdayOpt\": 1398956159, \"weight\": \(weight), \"float\": \(float), \"friend\": \(subUserJSON), \"friendDictionary\":{ \"bestFriend\": \(subUserJSON)}}"
+        let userJSONString = "{\"username\":\"\(username)\",\"identifier\":\"\(identifier)\",\"photoCount\":\(photoCount),\"age\":\(age),\"drinker\":\(drinker),\"smoker\":\(smoker), \"arr\":[ \"bla\", true, 42 ], \"dict\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"arrOpt\":[ \"bla\", true, 42 ], \"dictOpt\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"birthday\": 1398956159, \"birthdayOpt\": 1398956159, \"y2k\" : \"2000-01-01T00:00:00Z\", \"y2kOpt\" : \"2000-01-01T00:00:00Z\", \"weight\": \(weight), \"float\": \(float), \"friend\": \(subUserJSON), \"friendDictionary\":{ \"bestFriend\": \(subUserJSON)}}"
 		
 		let user = Mapper().map(string: userJSONString, toType: User.self)
-        
+
         XCTAssertEqual(username, user.username, "Username should be the same")
         XCTAssertEqual(identifier, user.identifier!, "Identifier should be the same")
         XCTAssertEqual(photoCount, user.photoCount, "PhotoCount should be the same")
@@ -55,7 +56,9 @@ class ObjectMapperTests: XCTestCase {
         XCTAssertEqual(smoker, user.smoker!, "Smoker should be the same")
         XCTAssertEqual(birthday, user.birthday, "Birthday should be the same")
         XCTAssertEqual(birthday, user.birthdayOpt!, "Birthday should be the same")
-        
+        XCTAssertEqual(y2k, user.y2k, "Y2K date should be the same")
+        XCTAssertEqual(y2k, user.y2kOpt!, "Y2K date should be the same")
+
         println(Mapper().toJSONString(user, prettyPrint: true))
     }
 	
@@ -70,15 +73,16 @@ class ObjectMapperTests: XCTestCase {
         let smoker = false
         let arr = [ "bla", true, 42 ]
         let birthday = NSDate(timeIntervalSince1970: 1398956159)
+        let y2k = NSDate(timeIntervalSince1970: 946684800)
         let directory = [
             "key1" : "value1",
             "key2" : false,
             "key3" : 142
         ]
         
-        let subUserJSON = "{\"identifier\" : \"user8723\", \"drinker\" : true, \"age\": 17,\"birthdayOpt\" : 1398956159, \"username\" : \"sub user\" }"
+        let subUserJSON = "{\"identifier\" : \"user8723\", \"drinker\" : true, \"age\": 17,\"birthdayOpt\" : 1398956159, \"y2kOpt\" : \"2000-01-01T00:00:00Z\", \"username\" : \"sub user\" }"
         
-        let userJSONString = "{\"username\":\"\(username)\",\"identifier\":\"\(identifier)\",\"photoCount\":\(photoCount),\"age\":\(age),\"drinker\":\(drinker),\"smoker\":\(smoker), \"arr\":[ \"bla\", true, 42 ], \"dict\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"arrOpt\":[ \"bla\", true, 42 ], \"dictOpt\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"birthday\": 1398956159, \"birthdayOpt\": 1398956159, \"weight\": \(weight), \"float\": \(float), \"friend\": \(subUserJSON), \"friendDictionary\":{ \"bestFriend\": \(subUserJSON)}}"
+        let userJSONString = "{\"username\":\"\(username)\",\"identifier\":\"\(identifier)\",\"photoCount\":\(photoCount),\"age\":\(age),\"drinker\":\(drinker),\"smoker\":\(smoker), \"arr\":[ \"bla\", true, 42 ], \"dict\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"arrOpt\":[ \"bla\", true, 42 ], \"dictOpt\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"birthday\": 1398956159, \"birthdayOpt\": 1398956159, \"y2k\" : \"2000-01-01T00:00:00Z\", \"y2kOpt\" : \"2000-01-01T00:00:00Z\", \"weight\": \(weight), \"float\": \(float), \"friend\": \(subUserJSON), \"friendDictionary\":{ \"bestFriend\": \(subUserJSON)}}"
         
         let user = Mapper().map(string: userJSONString, toObject: User())
         
@@ -92,7 +96,9 @@ class ObjectMapperTests: XCTestCase {
         XCTAssertEqual(smoker, user.smoker!, "Smoker should be the same")
         XCTAssertEqual(birthday, user.birthday, "Birthday should be the same")
         XCTAssertEqual(birthday, user.birthdayOpt!, "Birthday should be the same")
-        
+        XCTAssertEqual(y2k, user.y2k, "Y2K date should be the same")
+        XCTAssertEqual(y2k, user.y2kOpt!, "Y2K date should be the same")
+
         println(Mapper().toJSONString(user, prettyPrint: true))
     }
     
@@ -117,6 +123,7 @@ class ObjectMapperTests: XCTestCase {
         user.smoker = false
         user.arr = ["cheese", 11234]
         user.birthday = NSDate()
+        user.y2k = NSDate(timeIntervalSince1970: 946684800)
         user.imageURL = NSURL(string: "http://google.com/image/1234")
         
         let jsonString = Mapper().toJSONString(user, prettyPrint: true)
@@ -132,9 +139,9 @@ class ObjectMapperTests: XCTestCase {
         XCTAssertEqual(user.smoker!, parsedUser.smoker!, "Smoker should be the same")
         XCTAssertEqual(user.imageURL!, parsedUser.imageURL!, "Image URL should be the same")
 //        XCTAssert(user.birthday.compare(parsedUser.birthday) == .OrderedSame, "Birthday should be the same")
-        
+        XCTAssert(user.y2k.compare(parsedUser.y2k) == .OrderedSame, "Y2k should be the same")
     }
-    
+
     func testUnknownPropertiesIgnored() {
         let userJSONString = "{\"username\":\"bob\",\"identifier\":\"bob1987\", \"foo\" : \"bar\", \"fooArr\" : [ 1, 2, 3], \"fooObj\" : { \"baz\" : \"qux\" } }"
         let user = Mapper().map(string: userJSONString, toType: User.self)
@@ -305,6 +312,8 @@ class User: MapperProtocol {
     var friends: [User]? = []
     var birthday: NSDate = NSDate()
     var birthdayOpt: NSDate?
+    var y2k: NSDate = NSDate()
+    var y2kOpt: NSDate?
     var imageURL: NSURL?
 	var heightInCM: Double?
 	
@@ -331,11 +340,13 @@ class User: MapperProtocol {
 		dictString		 <= mapper["dictString"]
 		birthday         <= (mapper["birthday"], DateTransform<NSDate, Double>())
 		birthdayOpt      <= (mapper["birthdayOpt"], DateTransform<NSDate, Double>())
+        y2k              <= (mapper["y2k"], ISO8601DateTransform<NSDate, String>())
+        y2kOpt           <= (mapper["y2kOpt"], ISO8601DateTransform<NSDate, String>())
 		imageURL         <= (mapper["imageURL"], URLTransform<NSURL, String>())
 		heightInCM		 <= mapper["height.value"]
 	}
 	
     var description : String {
-        return "username: \(username) \nid:\(identifier) \nage: \(age) \nphotoCount: \(photoCount) \ndrinker: \(drinker) \nsmoker: \(smoker) \narr: \(arr) \narrOptional: \(arrOptional) \ndict: \(dict) \ndictOptional: \(dictOptional) \nfriend: \(friend)\nfriends: \(friends)\nbirthday: \(birthday)\nbirthdayOpt: \(birthdayOpt)\nweight: \(weight)"
+        return "username: \(username) \nid:\(identifier) \nage: \(age) \nphotoCount: \(photoCount) \ndrinker: \(drinker) \nsmoker: \(smoker) \narr: \(arr) \narrOptional: \(arrOptional) \ndict: \(dict) \ndictOptional: \(dictOptional) \nfriend: \(friend)\nfriends: \(friends) \nbirthday: \(birthday)\nbirthdayOpt: \(birthdayOpt) \ny2k: \(y2k) \ny2kOpt: \(y2k) \nweight: \(weight)"
     }
 }


### PR DESCRIPTION
The existing `DateTransform` handles seconds from epoch, but other date representations can by handy - this PR adds support for [ISO 8601 dates](http://en.wikipedia.org/wiki/ISO_8601) like `2000-01-01T00:00:00Z`.