### PR TITLE
Fixes crash when trying to transform invalid urlString

### DIFF
--- a/ObjectMapper/Transforms/URLTransform.swift
+++ b/ObjectMapper/Transforms/URLTransform.swift
@@ -16,7 +16,10 @@ public class URLTransform<ObjectType, JSONType>: MapperTransform<ObjectType, JSO
     
     override public func transformFromJSON(value: AnyObject?) -> ObjectType? {
         if let URLString = value as? String {
-            return (NSURL(string: URLString) as ObjectType)
+            let url = NSURL(string: URLString)
+            if let unwrappedUrl = url {
+                return (url as ObjectType)
+            }
         }
         return nil
     }


### PR DESCRIPTION
Currently, trying to transform a Sting that does not represent a valid url to a NSURL results in a crash.
Invoking NSURL(string: URLString) with an invalid String results in nil. Afterwards, nil is cast to ObjectType, which is impossible and crashes.
This pull request fixes that bug.