### PR TITLE
Fix ISO8601DateTransform not to crash with invalid input

### DIFF
--- a/ObjectMapper/Transforms/ISO8601DateTransform.swift
+++ b/ObjectMapper/Transforms/ISO8601DateTransform.swift
@@ -21,7 +21,7 @@ public class ISO8601DateTransform<ObjectType, JSONType>: MapperTransform<ObjectT
 
     override public func transformFromJSON(value: AnyObject?) -> ObjectType? {
         if let dateString = value as? String {
-            return (dateFormatter().dateFromString(dateString) as ObjectType)
+            return (dateFormatter().dateFromString(dateString) as ObjectType?)
         }
         return nil
     }

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -299,6 +299,22 @@ class ObjectMapperTests: XCTestCase {
 		XCTAssertEqual(taskId3, task3.taskId!, "TaskId3 was not mapped correctly")
 		XCTAssertEqual(percentage3, task3.percentage!, "percentage3 was not mapped correctly")
 	}
+
+    func testISO8601DateTransformWithInvalidInput() {
+        let mapper = Mapper()
+
+        var JSON: [String: AnyObject] = ["y2kOpt": ""]
+        let user1 = mapper.map(JSON, toType: User.self)
+
+        XCTAssert(user1 != nil, "ISO8601DateTransform must not crash for empty string")
+        XCTAssert(user1.y2kOpt == nil, "ISO8601DateTransform should return nil for empty string")
+
+        JSON["y2kOpt"] = "incorrect format"
+        let user2 = mapper.map(JSON, toType: User.self)
+
+        XCTAssert(user2 != nil, "ISO8601DateTransform must not crash for incorrect format")
+        XCTAssert(user2.y2kOpt == nil, "ISO8601DateTransform should return nil for incorrect format")
+    }
 }
 
 class Response<T:MapperProtocol>: MapperProtocol {


### PR DESCRIPTION
`NSDateFormatter.dateFromString` returns optional value. If the input value is invalid (empty string, incorrect format), it leads to crash because of force unwrapping nil value.