### PR TITLE
Make Mapper class itself generic, :fire: `toType` parameter

### DIFF
--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -74,13 +74,13 @@ class FromJSON<CollectionType> {
     
     func object<N: Mappable>(inout field: N, object: AnyObject?) {
         if let value = object as? [String : AnyObject] {
-            field = Mapper().map(value, toType: N.self)
+            field = Mapper().map(value)
         }
     }
     
     func object<N: Mappable>(inout field: N?, object: AnyObject?) {
         if let value = object as? [String : AnyObject] {
-            field = Mapper().map(value, toType: N.self)
+            field = Mapper().map(value)
         }
     }
     
@@ -104,14 +104,14 @@ class FromJSON<CollectionType> {
     
     // parses a JSON array into an array of objects of type <N: Mappable>
     private func parseObjectArray<N: Mappable>(object: AnyObject?) -> Array<N>{
-        let mapper = Mapper()
+        let mapper = Mapper<N>()
         
         var parsedObjects = Array<N>()
         
         if let array = object as [AnyObject]? {
             for object in array {
                 let objectJSON = object as [String : AnyObject]
-                var parsedObj = mapper.map(objectJSON, toType: N.self)
+                var parsedObj = mapper.map(objectJSON)
                 parsedObjects.append(parsedObj)
             }
         }
@@ -141,14 +141,14 @@ class FromJSON<CollectionType> {
     
     // parses a JSON Dictionary into an Dictionay of objects of type <N: Mappable>
     private func parseObjectDictionary<N: Mappable>(object: AnyObject?) -> Dictionary<String, N>{
-        let mapper = Mapper()
+        let mapper = Mapper<N>()
         
         var parsedObjectsDictionary = Dictionary<String, N>()
         
         if let dictionary = object as Dictionary<String, AnyObject>? {
             for (key, object) in dictionary {
                 let objectJSON = object as [String : AnyObject]
-                var parsedObj = mapper.map(objectJSON, toType: N.self)
+                var parsedObj = mapper.map(objectJSON)
                 parsedObjectsDictionary[key] = parsedObj
             }
         }

--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol Mappable {
-    mutating func map(mapper: Mapper)
+    mutating func map<N>(mapper: Mapper<N>)
     init()
 }
 
@@ -18,7 +18,7 @@ enum MappingType {
     case toJSON
 }
 
-public class Mapper {
+public class Mapper<N: Mappable> {
     var JSONDictionary: [String : AnyObject] = [:]
     var currentValue: AnyObject?
     var currentKey: String?
@@ -43,7 +43,7 @@ public class Mapper {
     }
     
     // map a JSON string onto an existing object
-    public func map<N: Mappable>(string JSON: String, var toObject object: N) -> N! {
+    public func map(string JSON: String, var toObject object: N) -> N! {
         var json = parseJSONDictionary(JSON)
         if let json = json {
             mappingType = .fromJSON
@@ -56,23 +56,23 @@ public class Mapper {
     }
     
     // map a JSON string to an object Type that conforms to Mappable
-    public func map<N: Mappable>(string JSONString: String, toType type: N.Type) -> N! {
+    public func map(string JSONString: String) -> N! {
         var json = parseJSONDictionary(JSONString)
         if let json = json {
-            return map(json, toType: type)
+            return map(json)
         }
         return nil
     }
     
     // maps a JSON dictionary to an object that conforms to Mappable
-    public func map<N: Mappable>(JSON: [String : AnyObject], toType type: N.Type) -> N! {
+    public func map(JSON: [String : AnyObject]) -> N! {
         var object = N()
         return map(JSON, toObject: object)
     }
     
     // maps a JSON dictionary to an existing object that conforms to Mappable.
     // Usefull for those pesky objects that have crappy designated initializers like NSManagedObject
-    public func map<N: Mappable>(JSON: [String : AnyObject], var toObject object: N) -> N! {
+    public func map(JSON: [String : AnyObject], var toObject object: N) -> N! {
         mappingType = .fromJSON
         self.JSONDictionary = JSON
         object.map(self)
@@ -80,23 +80,23 @@ public class Mapper {
     }
 
 	// maps a JSON array to an object that conforms to Mappable
-	public func mapArray<N: Mappable>(string JSONString: String, toType type: N.Type) -> [N]! {
+	public func mapArray(string JSONString: String) -> [N]! {
 		var jsonArray = parseJSONArray(JSONString)
 		if let jsonArray = jsonArray {
-			return mapArray(jsonArray, toType: type)
+			return mapArray(jsonArray)
 		} else {
 			// failed to parse JSON into array form
 			// try to parse it into a dictionary and then wrap it in an array
 			var jsonDict = parseJSONDictionary(JSONString)
 			if let jsonDict = jsonDict {
-				return mapArray([jsonDict], toType: type)
+				return mapArray([jsonDict])
 			}
 		}
 		return nil
 	}
 	
 	// maps a JSON dictionary to an object that conforms to Mappable
-	public func mapArray<N: Mappable>(JSON: [[String : AnyObject]], toType type: N.Type) -> [N] {
+	public func mapArray(JSON: [[String : AnyObject]]) -> [N] {
 		mappingType = .fromJSON
 		
 		var objects: Array<N> = []
@@ -113,7 +113,7 @@ public class Mapper {
 	}
 	
     // maps an Object to a JSON dictionary <String : AnyObject>
-    public func toJSON<N: Mappable>(var object: N) -> [String : AnyObject] {
+    public func toJSON(var object: N) -> [String : AnyObject] {
         mappingType = .toJSON
         
         self.JSONDictionary = [String : AnyObject]()
@@ -123,7 +123,7 @@ public class Mapper {
     }
 	
 	// maps an array of Objects to an array of JSON dictionaries [[String : AnyObject]]
-	public func toJSONArray<N: Mappable>(array: [N]) -> [[String : AnyObject]] {
+	public func toJSONArray(array: [N]) -> [[String : AnyObject]] {
 		mappingType = .toJSON
 		
 		var JSONArray = [[String : AnyObject]]()
@@ -138,7 +138,7 @@ public class Mapper {
 	}
 	
     // maps an Object to a JSON string
-    public func toJSONString<N: Mappable>(object: N, prettyPrint: Bool) -> String! {
+    public func toJSONString(object: N, prettyPrint: Bool) -> String! {
         let JSONDict = toJSON(object)
         
         var err: NSError?

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -13,7 +13,7 @@ import Foundation
 //infix operator <= {}
 
 // MARK: basic type
-public func <=<T>(inout left: T, right: Mapper) {
+public func <=<T, U>(inout left: T, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().baseType(&left, object: right.currentValue)
     } else {
@@ -22,7 +22,7 @@ public func <=<T>(inout left: T, right: Mapper) {
 }
 
 // Optional basic type
-public func <=<T>(inout left: T?, right: Mapper) {
+public func <=<T, U>(inout left: T?, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().optionalBaseType(&left, object: right.currentValue)
     } else {
@@ -31,7 +31,7 @@ public func <=<T>(inout left: T?, right: Mapper) {
 }
 
 // Basic type with Transform
-public func <=<T, N>(inout left: T, right: (Mapper, MapperTransform<T, N>)) {
+public func <=<T, U, N>(inout left: T, right: (Mapper<U>, MapperTransform<T, N>)) {
     if right.0.mappingType == MappingType.fromJSON {
         var value: T? = right.1.transformFromJSON(right.0.currentValue)
         //println("FromJSON \(value)");
@@ -44,7 +44,7 @@ public func <=<T, N>(inout left: T, right: (Mapper, MapperTransform<T, N>)) {
 }
 
 // Optional basic type with Transform
-public func <=<T, N>(inout left: T?, right: (Mapper, MapperTransform<T, N>)) {
+public func <=<T, U, N>(inout left: T?, right: (Mapper<U>, MapperTransform<T, N>)) {
     if right.0.mappingType == MappingType.fromJSON {
         var value: T? = right.1.transformFromJSON(right.0.currentValue)
         //println("FromJSON \(value)");
@@ -57,7 +57,7 @@ public func <=<T, N>(inout left: T?, right: (Mapper, MapperTransform<T, N>)) {
 }
 
 // MARK:- T: Mappable
-public func <=<T: Mappable>(inout left: T, right: Mapper) {
+public func <=<T: Mappable, U>(inout left: T, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().object(&left, object: right.currentValue)
     } else {
@@ -66,7 +66,7 @@ public func <=<T: Mappable>(inout left: T, right: Mapper) {
 }
 
 // Optional object conforming to Mappable
-public func <=<T: Mappable>(inout left: T?, right: Mapper) {
+public func <=<T: Mappable, U>(inout left: T?, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().object(&left, object: right.currentValue)
     } else {
@@ -75,7 +75,7 @@ public func <=<T: Mappable>(inout left: T?, right: Mapper) {
 }
 
 // MARK:- Dictionary <String, T: Mappable>
-public func <=<T: Mappable>(inout left: Dictionary<String, T>, right: Mapper) {
+public func <=<T: Mappable, U>(inout left: Dictionary<String, T>, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().objectDictionary(&left, object: right.currentValue)
     } else {
@@ -84,7 +84,7 @@ public func <=<T: Mappable>(inout left: Dictionary<String, T>, right: Mapper) {
 }
 
 // Optional Dictionary <String, T: Mappable>
-public func <=<T: Mappable>(inout left: Dictionary<String, T>?, right: Mapper) {
+public func <=<T: Mappable, U>(inout left: Dictionary<String, T>?, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().optionalObjectDictionary(&left, object: right.currentValue)
     } else {
@@ -93,7 +93,7 @@ public func <=<T: Mappable>(inout left: Dictionary<String, T>?, right: Mapper) {
 }
 
 // MARK: Dictionary <String, AnyObject>
-public func <=(inout left: Dictionary<String, AnyObject>, right: Mapper) {
+public func <=<U>(inout left: Dictionary<String, AnyObject>, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<AnyObject>().baseType(&left, object: right.currentValue)
     } else {
@@ -102,7 +102,7 @@ public func <=(inout left: Dictionary<String, AnyObject>, right: Mapper) {
 }
 
 // Optional dictionary <String, AnyObject>
-public func <=(inout left: Dictionary<String, AnyObject>?, right: Mapper) {
+public func <=<U>(inout left: Dictionary<String, AnyObject>?, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<AnyObject>().optionalBaseType(&left, object: right.currentValue)
     } else {
@@ -111,7 +111,7 @@ public func <=(inout left: Dictionary<String, AnyObject>?, right: Mapper) {
 }
 
 // MARK:- Array<T: Mappable>
-public func <=<T: Mappable>(inout left: Array<T>, right: Mapper) {
+public func <=<T: Mappable, U>(inout left: Array<T>, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().objectArray(&left, object: right.currentValue)
     } else {
@@ -120,7 +120,7 @@ public func <=<T: Mappable>(inout left: Array<T>, right: Mapper) {
 }
 
 // Optional array of objects conforming to Mappable
-public func <=<T: Mappable>(inout left: Array<T>?, right: Mapper) {
+public func <=<T: Mappable, U>(inout left: Array<T>?, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().optionalObjectArray(&left, object: right.currentValue)
     } else {
@@ -129,7 +129,7 @@ public func <=<T: Mappable>(inout left: Array<T>?, right: Mapper) {
 }
 
 // MARK: Array<AnyObject>
-public func <=(inout left: Array<AnyObject>, right: Mapper) {
+public func <=<U>(inout left: Array<AnyObject>, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<AnyObject>().baseType(&left, object: right.currentValue)
     } else {
@@ -138,7 +138,7 @@ public func <=(inout left: Array<AnyObject>, right: Mapper) {
 }
 
 // Optional array of String type
-public func <=(inout left: Array<AnyObject>?, right: Mapper) {
+public func <=<U>(inout left: Array<AnyObject>?, right: Mapper<U>) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<AnyObject>().optionalBaseType(&left, object: right.currentValue)
     } else {

--- a/ObjectMapper/Core/ToJSON.swift
+++ b/ObjectMapper/Core/ToJSON.swift
@@ -88,7 +88,7 @@ class ToJSON {
     }
     
     func object<N: Mappable>(field: N, key: String, inout dictionary: [String : AnyObject]) {
-        let mapper = Mapper()
+        let mapper = Mapper<N>()
         
         dictionary[key] = NSDictionary(dictionary: mapper.toJSON(field))
     }
@@ -103,7 +103,7 @@ class ToJSON {
         var JSONObjects = NSMutableArray()
         
         for object in field {
-            let mapper = Mapper()
+            let mapper = Mapper<N>()
             JSONObjects.addObject(mapper.toJSON(object))
         }
 
@@ -122,7 +122,7 @@ class ToJSON {
         var JSONObjects = NSMutableDictionary()
         
         for (k, object) in field {
-            let mapper = Mapper()
+            let mapper = Mapper<N>()
             JSONObjects.setObject(mapper.toJSON(object), forKey: k)
 
         }

--- a/ObjectMapperTests/BasicTypesTests.swift
+++ b/ObjectMapperTests/BasicTypesTests.swift
@@ -32,7 +32,7 @@ class BasicTypesTests: XCTestCase {
 		object.boolOptional = value
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 
@@ -50,7 +50,7 @@ class BasicTypesTests: XCTestCase {
 		object.intOptional = value
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			
@@ -68,7 +68,7 @@ class BasicTypesTests: XCTestCase {
 		object.doubleOptional = value
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			
@@ -86,7 +86,7 @@ class BasicTypesTests: XCTestCase {
 		object.floatOptional = value
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			
@@ -104,7 +104,7 @@ class BasicTypesTests: XCTestCase {
 		object.stringOptional = value
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			
@@ -124,7 +124,7 @@ class BasicTypesTests: XCTestCase {
 		object.arrayBoolOptional = [value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			var firstObject = mappedObject.arrayBool[0]
@@ -142,7 +142,7 @@ class BasicTypesTests: XCTestCase {
 		object.arrayIntOptional = [value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			var firstObject = mappedObject.arrayInt[0]
@@ -160,7 +160,7 @@ class BasicTypesTests: XCTestCase {
 		object.arrayDoubleOptional = [value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			var firstObject = mappedObject.arrayDouble[0]
@@ -178,7 +178,7 @@ class BasicTypesTests: XCTestCase {
 		object.arrayFloatOptional = [value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			var firstObject = mappedObject.arrayFloat[0]
@@ -196,7 +196,7 @@ class BasicTypesTests: XCTestCase {
 		object.arrayStringOptional = [value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			var firstObject = mappedObject.arrayString[0]
@@ -217,7 +217,7 @@ class BasicTypesTests: XCTestCase {
 		object.dictBoolOptional = [key:value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			if let val = mappedObject.dictBoolOptional?[key] {
@@ -237,7 +237,7 @@ class BasicTypesTests: XCTestCase {
 		object.dictIntOptional = [key:value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			if let val = mappedObject.dictIntOptional?[key] {
@@ -257,7 +257,7 @@ class BasicTypesTests: XCTestCase {
 		object.dictDoubleOptional = [key:value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			if let val = mappedObject.dictDoubleOptional?[key] {
@@ -277,7 +277,7 @@ class BasicTypesTests: XCTestCase {
 		object.dictFloatOptional = [key:value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			if let val = mappedObject.dictFloatOptional?[key] {
@@ -297,7 +297,7 @@ class BasicTypesTests: XCTestCase {
 		object.dictStringOptional = [key:value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper().map(string: JSON, toType: BasicTypes.self)
+		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			if let val = mappedObject.dictStringOptional?[key] {
@@ -347,7 +347,7 @@ class BasicTypes: Mappable {
 	required init() {
 	}
 	
-	func map(mapper: Mapper) {
+	func map<N>(mapper: Mapper<N>) {
 		bool			<= mapper["bool"]
 		boolOptional	<= mapper["boolOpt"]
 		int				<= mapper["int"]

--- a/ObjectMapperTests/BasicTypesTests.swift
+++ b/ObjectMapperTests/BasicTypesTests.swift
@@ -12,6 +12,8 @@ import ObjectMapper
 
 class BasicTypesTests: XCTestCase {
 
+    let mapper = Mapper<BasicTypes>()
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -32,7 +34,7 @@ class BasicTypesTests: XCTestCase {
 		object.boolOptional = value
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 
@@ -50,7 +52,7 @@ class BasicTypesTests: XCTestCase {
 		object.intOptional = value
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			
@@ -68,7 +70,7 @@ class BasicTypesTests: XCTestCase {
 		object.doubleOptional = value
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			
@@ -86,7 +88,7 @@ class BasicTypesTests: XCTestCase {
 		object.floatOptional = value
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			
@@ -104,7 +106,7 @@ class BasicTypesTests: XCTestCase {
 		object.stringOptional = value
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			
@@ -124,7 +126,7 @@ class BasicTypesTests: XCTestCase {
 		object.arrayBoolOptional = [value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			var firstObject = mappedObject.arrayBool[0]
@@ -142,7 +144,7 @@ class BasicTypesTests: XCTestCase {
 		object.arrayIntOptional = [value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			var firstObject = mappedObject.arrayInt[0]
@@ -160,7 +162,7 @@ class BasicTypesTests: XCTestCase {
 		object.arrayDoubleOptional = [value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			var firstObject = mappedObject.arrayDouble[0]
@@ -178,7 +180,7 @@ class BasicTypesTests: XCTestCase {
 		object.arrayFloatOptional = [value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			var firstObject = mappedObject.arrayFloat[0]
@@ -196,7 +198,7 @@ class BasicTypesTests: XCTestCase {
 		object.arrayStringOptional = [value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			var firstObject = mappedObject.arrayString[0]
@@ -217,7 +219,7 @@ class BasicTypesTests: XCTestCase {
 		object.dictBoolOptional = [key:value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			if let val = mappedObject.dictBoolOptional?[key] {
@@ -237,7 +239,7 @@ class BasicTypesTests: XCTestCase {
 		object.dictIntOptional = [key:value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			if let val = mappedObject.dictIntOptional?[key] {
@@ -257,7 +259,7 @@ class BasicTypesTests: XCTestCase {
 		object.dictDoubleOptional = [key:value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			if let val = mappedObject.dictDoubleOptional?[key] {
@@ -277,7 +279,7 @@ class BasicTypesTests: XCTestCase {
 		object.dictFloatOptional = [key:value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			if let val = mappedObject.dictFloatOptional?[key] {
@@ -297,7 +299,7 @@ class BasicTypesTests: XCTestCase {
 		object.dictStringOptional = [key:value]
 		
 		let JSON = Mapper().toJSONString(object, prettyPrint: true)
-		var mappedObject = Mapper<BasicTypes>().map(string: JSON)
+		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
 			if let val = mappedObject.dictStringOptional?[key] {

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -44,7 +44,7 @@ class ObjectMapperTests: XCTestCase {
         
         let userJSONString = "{\"username\":\"\(username)\",\"identifier\":\"\(identifier)\",\"photoCount\":\(photoCount),\"age\":\(age),\"drinker\":\(drinker),\"smoker\":\(smoker), \"arr\":[ \"bla\", true, 42 ], \"dict\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"arrOpt\":[ \"bla\", true, 42 ], \"dictOpt\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"birthday\": 1398956159, \"birthdayOpt\": 1398956159, \"y2k\" : \"2000-01-01T00:00:00Z\", \"y2kOpt\" : \"2000-01-01T00:00:00Z\", \"weight\": \(weight), \"float\": \(float), \"friend\": \(subUserJSON), \"friendDictionary\":{ \"bestFriend\": \(subUserJSON)}}"
 		
-		let user = Mapper().map(string: userJSONString, toType: User.self)
+		let user = Mapper<User>().map(string: userJSONString)
 
         XCTAssertEqual(username, user.username, "Username should be the same")
         XCTAssertEqual(identifier, user.identifier!, "Identifier should be the same")
@@ -138,7 +138,7 @@ class ObjectMapperTests: XCTestCase {
 		
 		let userJSONString = "{\"username\":\"bob\", \"height\": {\"value\": \(heightInCM), \"text\": \"6 feet tall\"} }"
 		
-		let user = Mapper().map(string: userJSONString, toType: User.self)
+		let user = Mapper<User>().map(string: userJSONString)
 
 		XCTAssertEqual(user.heightInCM!, heightInCM, "Username should be the same")
 	}
@@ -146,7 +146,7 @@ class ObjectMapperTests: XCTestCase {
 	func testNullObject() {
 		let userJSONString = "{\"username\":\"bob\"}"
 		
-		let user = Mapper().map(string: userJSONString, toType: User.self)
+		let user = Mapper<User>().map(string: userJSONString)
 		
 		XCTAssert(user.heightInCM == nil, "Username should be the same")
 	}
@@ -168,7 +168,7 @@ class ObjectMapperTests: XCTestCase {
         
         let jsonString = Mapper().toJSONString(user, prettyPrint: true)
         println(jsonString)
-		var parsedUser = Mapper().map(string: jsonString, toType: User.self)
+		var parsedUser = Mapper<User>().map(string: jsonString)
         
 		
         XCTAssertEqual(user.identifier!, parsedUser.identifier!, "Identifier should be the same")
@@ -185,7 +185,7 @@ class ObjectMapperTests: XCTestCase {
 
     func testUnknownPropertiesIgnored() {
         let userJSONString = "{\"username\":\"bob\",\"identifier\":\"bob1987\", \"foo\" : \"bar\", \"fooArr\" : [ 1, 2, 3], \"fooObj\" : { \"baz\" : \"qux\" } }"
-        let user = Mapper().map(string: userJSONString, toType: User.self)
+        let user = Mapper<User>().map(string: userJSONString)
         
         XCTAssert(user != nil, "User should not be nil")
     }
@@ -193,7 +193,7 @@ class ObjectMapperTests: XCTestCase {
     func testInvalidJsonResultsInNilObject() {
         let userJSONString = "{\"username\":\"bob\",\"identifier\":\"bob1987\"" // missing ending brace
 
-        let user = Mapper().map(string: userJSONString, toType: User.self)
+        let user = Mapper<User>().map(string: userJSONString)
 		
         XCTAssert(user == nil, "User should be nil due to invalid JSON")
     }
@@ -204,7 +204,7 @@ class ObjectMapperTests: XCTestCase {
 		
 		let arrayJSONString = "[{\"name\": \"\(name1)\", \"UUID\": \"3C074D4B-FC8C-4CA2-82A9-6E9367BBC875\", \"major\": 541, \"minor\": 123},{ \"name\": \"\(name2)\", \"UUID\": \"3C074D4B-FC8C-4CA2-82A9-6E9367BBC876\", \"major\": 54321,\"minor\": 13 }]"
 	
-		let studentArray = Mapper().mapArray(string: arrayJSONString, toType: Student.self)
+		let studentArray = Mapper<Student>().mapArray(string: arrayJSONString)
 		
 		if let students = studentArray {
 			XCTAssert(students.count == 2, "There should be 2 students in array")
@@ -222,7 +222,7 @@ class ObjectMapperTests: XCTestCase {
 		
 		let arrayJSONString = "{\"name\": \"\(name1)\", \"UUID\": \"3C074D4B-FC8C-4CA2-82A9-6E9367BBC875\", \"major\": 541, \"minor\": 123}"
 		
-		let studentArray = Mapper().mapArray(string: arrayJSONString, toType: Student.self)
+		let studentArray = Mapper<Student>().mapArray(string: arrayJSONString)
 		
 		if let students = studentArray {
 			XCTAssert(students.count == 1, "There should be 2 students in array")
@@ -239,7 +239,7 @@ class ObjectMapperTests: XCTestCase {
 		
 		let JSON = "{ \"tasks\": [{\"taskId\":103,\"percentage\":\(percentage1)},{\"taskId\":108,\"percentage\":\(percentage2)}] }"
 		
-		let plan = Mapper().map(string: JSON, toType: Plan.self)
+		let plan = Mapper<Plan>().map(string: JSON)
 		
 		if let tasks = plan.tasks {
 			let task1 = tasks[0]
@@ -256,7 +256,7 @@ class ObjectMapperTests: XCTestCase {
 		let code: Int = 22
 		let JSON = "{\"result\":{\"code\":\(code)}}"
 		
-		let response = Mapper().map(string: JSON, toType: Response<Status>.self)
+		let response = Mapper<Response<Status>>().map(string: JSON)
 		
 		if let status = response.result?.status {
 			XCTAssertEqual(status, code, "Code was not mapped correctly")
@@ -301,16 +301,16 @@ class ObjectMapperTests: XCTestCase {
 	}
 
     func testISO8601DateTransformWithInvalidInput() {
-        let mapper = Mapper()
+        let mapper = Mapper<User>()
 
         var JSON: [String: AnyObject] = ["y2kOpt": ""]
-        let user1 = mapper.map(JSON, toType: User.self)
+        let user1 = mapper.map(JSON)
 
         XCTAssert(user1 != nil, "ISO8601DateTransform must not crash for empty string")
         XCTAssert(user1.y2kOpt == nil, "ISO8601DateTransform should return nil for empty string")
 
         JSON["y2kOpt"] = "incorrect format"
-        let user2 = mapper.map(JSON, toType: User.self)
+        let user2 = mapper.map(JSON)
 
         XCTAssert(user2 != nil, "ISO8601DateTransform must not crash for incorrect format")
         XCTAssert(user2.y2kOpt == nil, "ISO8601DateTransform should return nil for incorrect format")
@@ -323,7 +323,7 @@ class Response<T:Mappable>: Mappable {
 	required init() {
 	}
 	
-	func map(mapper: Mapper) {
+	func map<N>(mapper: Mapper<N>) {
 		result <= mapper["result"]
 	}
 }
@@ -334,7 +334,7 @@ class Status: Mappable {
 	required init() {
 	}
 	
-	func map(mapper: Mapper) {
+	func map<N>(mapper: Mapper<N>) {
 		status <= mapper["code"]
 	}
 }
@@ -346,7 +346,7 @@ class Plan: Mappable {
 		
 	}
 	
-	func map(mapper: Mapper) {
+	func map<N>(mapper: Mapper<N>) {
 		tasks <= mapper["tasks"]
 	}
 }
@@ -359,7 +359,7 @@ class Task: Mappable {
 		
 	}
 	
-	func map(mapper: Mapper) {
+	func map<N>(mapper: Mapper<N>) {
 		taskId <= mapper["taskId"]
 		percentage <= mapper["percentage"]
 	}
@@ -376,7 +376,7 @@ struct Student: Mappable {
 		
 	}
 	
-	mutating func map(mapper: Mapper) {
+	mutating func map<N>(mapper: Mapper<N>) {
 		name <= mapper["name"]
 		UUID <= mapper["UUID"]
 		major <= mapper["major"]
@@ -414,7 +414,7 @@ class User: Mappable {
 		
     }
 	
-	func map(mapper: Mapper) {
+	func map<N>(mapper: Mapper<N>) {
 		username         <= mapper["username"]
 		identifier       <= mapper["identifier"]
 		photoCount       <= mapper["photoCount"]

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -11,6 +11,8 @@ import XCTest
 import ObjectMapper
 
 class ObjectMapperTests: XCTestCase {
+
+    let userMapper = Mapper<User>()
     
     override func setUp() {
         super.setUp()
@@ -44,7 +46,7 @@ class ObjectMapperTests: XCTestCase {
         
         let userJSONString = "{\"username\":\"\(username)\",\"identifier\":\"\(identifier)\",\"photoCount\":\(photoCount),\"age\":\(age),\"drinker\":\(drinker),\"smoker\":\(smoker), \"arr\":[ \"bla\", true, 42 ], \"dict\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"arrOpt\":[ \"bla\", true, 42 ], \"dictOpt\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"birthday\": 1398956159, \"birthdayOpt\": 1398956159, \"y2k\" : \"2000-01-01T00:00:00Z\", \"y2kOpt\" : \"2000-01-01T00:00:00Z\", \"weight\": \(weight), \"float\": \(float), \"friend\": \(subUserJSON), \"friendDictionary\":{ \"bestFriend\": \(subUserJSON)}}"
 		
-		let user = Mapper<User>().map(string: userJSONString)
+		let user = userMapper.map(string: userJSONString)
 
         XCTAssertEqual(username, user.username, "Username should be the same")
         XCTAssertEqual(identifier, user.identifier!, "Identifier should be the same")
@@ -138,7 +140,7 @@ class ObjectMapperTests: XCTestCase {
 		
 		let userJSONString = "{\"username\":\"bob\", \"height\": {\"value\": \(heightInCM), \"text\": \"6 feet tall\"} }"
 		
-		let user = Mapper<User>().map(string: userJSONString)
+		let user = userMapper.map(string: userJSONString)
 
 		XCTAssertEqual(user.heightInCM!, heightInCM, "Username should be the same")
 	}
@@ -146,7 +148,7 @@ class ObjectMapperTests: XCTestCase {
 	func testNullObject() {
 		let userJSONString = "{\"username\":\"bob\"}"
 		
-		let user = Mapper<User>().map(string: userJSONString)
+		let user = userMapper.map(string: userJSONString)
 		
 		XCTAssert(user.heightInCM == nil, "Username should be the same")
 	}
@@ -168,7 +170,7 @@ class ObjectMapperTests: XCTestCase {
         
         let jsonString = Mapper().toJSONString(user, prettyPrint: true)
         println(jsonString)
-		var parsedUser = Mapper<User>().map(string: jsonString)
+		var parsedUser = userMapper.map(string: jsonString)
         
 		
         XCTAssertEqual(user.identifier!, parsedUser.identifier!, "Identifier should be the same")
@@ -185,7 +187,7 @@ class ObjectMapperTests: XCTestCase {
 
     func testUnknownPropertiesIgnored() {
         let userJSONString = "{\"username\":\"bob\",\"identifier\":\"bob1987\", \"foo\" : \"bar\", \"fooArr\" : [ 1, 2, 3], \"fooObj\" : { \"baz\" : \"qux\" } }"
-        let user = Mapper<User>().map(string: userJSONString)
+        let user = userMapper.map(string: userJSONString)
         
         XCTAssert(user != nil, "User should not be nil")
     }
@@ -193,7 +195,7 @@ class ObjectMapperTests: XCTestCase {
     func testInvalidJsonResultsInNilObject() {
         let userJSONString = "{\"username\":\"bob\",\"identifier\":\"bob1987\"" // missing ending brace
 
-        let user = Mapper<User>().map(string: userJSONString)
+        let user = userMapper.map(string: userJSONString)
 		
         XCTAssert(user == nil, "User should be nil due to invalid JSON")
     }
@@ -301,16 +303,14 @@ class ObjectMapperTests: XCTestCase {
 	}
 
     func testISO8601DateTransformWithInvalidInput() {
-        let mapper = Mapper<User>()
-
         var JSON: [String: AnyObject] = ["y2kOpt": ""]
-        let user1 = mapper.map(JSON)
+        let user1 = userMapper.map(JSON)
 
         XCTAssert(user1 != nil, "ISO8601DateTransform must not crash for empty string")
         XCTAssert(user1.y2kOpt == nil, "ISO8601DateTransform should return nil for empty string")
 
         JSON["y2kOpt"] = "incorrect format"
-        let user2 = mapper.map(JSON)
+        let user2 = userMapper.map(JSON)
 
         XCTAssert(user2 != nil, "ISO8601DateTransform must not crash for incorrect format")
         XCTAssert(user2.y2kOpt == nil, "ISO8601DateTransform should return nil for incorrect format")

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ class User: Mappable {
     required init(){}
 
     // Mappable    
-    func map(mapper: Mapper) {
+    func map<N>(mapper: Mapper<N>) {
         username <= mapper["username"]
         age <= mapper["age"]
         weight <= mapper["weight"]
@@ -43,7 +43,7 @@ struct Temperature: Mappable {
     
     init(){}
 	
-	mutating func map(mapper: Mapper) {
+	mutating func map<N>(mapper: Mapper<N>) {
 		celcius <= mapper["celcius"]
 		fahrenheit <= mapper["fahrenheit"]
 	}
@@ -54,7 +54,7 @@ Once your class implements Mappable, the Mapper class handles everything else fo
 
 Convert a JSON string to a model object:
 ```swift
-let user = Mapper().map(string: JSONString, toType: User.self)
+let user = Mapper<User>().map(string: JSONString)
 ```
 
 Convert a model object to a JSON string:
@@ -106,7 +106,7 @@ ObjectMapper supports dot notation within keys for easy mapping of nested object
 ```
 You can access the nested objects as follows:
 ```
-func map(mapper: Mapper){
+func map<N>(mapper: Mapper<N>){
     distance <= mapper["distance.value"]
 }
 ```


### PR DESCRIPTION
There is no more verbose `toType` parameter. Additionally this enables to reuse specialized mapper instance.