### PR TITLE
Make MappingType public, address #42

### DIFF
--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -13,7 +13,7 @@ public protocol Mappable {
 	init()
 }
 
-enum MappingType {
+public enum MappingType {
 	case fromJSON
 	case toJSON
 }


### PR DESCRIPTION
Because a non-public type can't be used from outside the framework target, it enables https://github.com/Hearst-DD/ObjectMapper/issues/42#issuecomment-73383167 way for framework usage.