### PR TITLE
Swift 1.2

### DIFF
--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -265,7 +265,7 @@ public final class Mapper<N: Mappable> {
 			}
 
 			if let JSON = JSONData {
-				return NSString(data: JSON, encoding: NSUTF8StringEncoding)
+				return NSString(data: JSON, encoding: NSUTF8StringEncoding) as! String
 			}
 		}
 

--- a/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -358,7 +358,7 @@ class BasicTypesTestsFromJSON: XCTestCase {
 	}
 	
 	func testObjectModelOptionalDictionnaryOfPrimitives() {
-		var json = ["dictStringString":["string": "string"], "dictStringBool":["string": false], "dictStringInt":["string": 1], "dictStringDouble":["string": 1.1], "dictStringFloat":["string": 1.2]]
+		var json: [String: [String: AnyObject]] = ["dictStringString":["string": "string"], "dictStringBool":["string": false], "dictStringInt":["string": 1], "dictStringDouble":["string": 1.1], "dictStringFloat":["string": 1.2]]
 		
 		let mapper = Mapper<TestCollectionOfPrimitives>()
 		let testSet = mapper.map(json)

--- a/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -107,9 +107,9 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
-			XCTAssert(mappedObject.anyObject as String == value1, "AnyObject failed")
-			XCTAssertEqual(mappedObject.anyObjectOptional! as Int, value2, "Implicity unwrapped optional String failed")
-			XCTAssertEqual(mappedObject.anyObjectImplicitlyUnwrapped as Double, value3, "Implicity unwrapped optional String failed")
+			XCTAssert(mappedObject.anyObject as! String == value1, "AnyObject failed")
+			XCTAssertEqual(mappedObject.anyObjectOptional! as! Int, value2, "Implicity unwrapped optional String failed")
+			XCTAssertEqual(mappedObject.anyObjectImplicitlyUnwrapped as! Double, value3, "Implicity unwrapped optional String failed")
 		} else {
 			XCTAssert(false, "JSON to String failed")
 		}
@@ -222,9 +222,9 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
-			XCTAssert(mappedObject.arrayAnyObject[0] as String == value1, "AnyObject array failed")
-			XCTAssertEqual(mappedObject.arrayAnyObjectOptional![0] as Int, value2, "Optional AnyObject array failed")
-			XCTAssertEqual(mappedObject.arrayAnyObjectImplicitlyUnwrapped[0] as Double, value3, "Implicity unwrapped optional AnyObject array failed")
+			XCTAssert(mappedObject.arrayAnyObject[0] as! String == value1, "AnyObject array failed")
+			XCTAssertEqual(mappedObject.arrayAnyObjectOptional![0] as! Int, value2, "Optional AnyObject array failed")
+			XCTAssertEqual(mappedObject.arrayAnyObjectImplicitlyUnwrapped[0] as! Double, value3, "Implicity unwrapped optional AnyObject array failed")
 		} else {
 			XCTAssert(false, "JSON to String failed")
 		}
@@ -344,13 +344,13 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
-			let val1 = mappedObject.dictAnyObject[key] as String
+			let val1 = mappedObject.dictAnyObject[key] as! String
 			XCTAssertEqual(val1, value1, "AnyObject Dictionary failed")
 			
-			let val2 = mappedObject.dictAnyObjectOptional?[key] as Int
+			let val2 = mappedObject.dictAnyObjectOptional?[key] as! Int
 			XCTAssertEqual(val2, value2, "Optional AnyObject Dictionary failed")
 			
-			let val3 = mappedObject.dictAnyObjectImplicitlyUnwrapped[key] as Double
+			let val3 = mappedObject.dictAnyObjectImplicitlyUnwrapped[key] as! Double
 			XCTAssertEqual(val3, value3, "Implicity unwrapped optional AnyObject Dictionary failed")
 		} else {
 			XCTAssert(false, "String Dictionary to JSON failed")

--- a/ObjectMapperTests/BasicTypesTestsToJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsToJSON.swift
@@ -132,9 +132,9 @@ class BasicTypesTestsToJSON: XCTestCase {
 		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
-			XCTAssertEqual(mappedObject.anyObject as String, value, "AnyObject failed")
-			XCTAssertEqual(mappedObject.anyObjectOptional! as String, value, "Optional AnyObject failed")
-			XCTAssertEqual(mappedObject.anyObjectImplicitlyUnwrapped as String, value, "Implicity unwrapped Optional AnyObject failed")
+			XCTAssertEqual(mappedObject.anyObject as! String, value, "AnyObject failed")
+			XCTAssertEqual(mappedObject.anyObjectOptional! as! String, value, "Optional AnyObject failed")
+			XCTAssertEqual(mappedObject.anyObjectImplicitlyUnwrapped as! String, value, "Implicity unwrapped Optional AnyObject failed")
 		} else {
 			XCTAssert(false, "String to JSON failed")
 		}
@@ -248,9 +248,9 @@ class BasicTypesTestsToJSON: XCTestCase {
 		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
-			XCTAssertEqual(mappedObject.arrayAnyObject[0] as String, value, "AnyObject Array failed")
-			XCTAssertEqual(mappedObject.arrayAnyObjectOptional![0] as String, value, "Optional AnyObject Array failed")
-			XCTAssertEqual(mappedObject.arrayAnyObjectImplicitlyUnwrapped[0] as String, value, "Implicity Unwrapped Optional AnyObject Array failed")
+			XCTAssertEqual(mappedObject.arrayAnyObject[0] as! String, value, "AnyObject Array failed")
+			XCTAssertEqual(mappedObject.arrayAnyObjectOptional![0] as! String, value, "Optional AnyObject Array failed")
+			XCTAssertEqual(mappedObject.arrayAnyObjectImplicitlyUnwrapped[0] as! String, value, "Implicity Unwrapped Optional AnyObject Array failed")
 		} else {
 			XCTAssert(false, "String Array to JSON failed")
 		}
@@ -370,9 +370,9 @@ class BasicTypesTestsToJSON: XCTestCase {
 		var mappedObject = mapper.map(string: JSON)
 		
 		if let mappedObject = mappedObject {
-			XCTAssertEqual(mappedObject.dictAnyObject[key]! as String, value, "AnyObject Dictionary failed")
-			XCTAssertEqual(mappedObject.dictAnyObjectOptional![key]! as String, value, "Optional AnyObject Dictionary failed")
-			XCTAssertEqual(mappedObject.dictAnyObjectImplicitlyUnwrapped[key]! as String, value, "Implicity unwrapped optional AnyObject Dictionary failed")
+			XCTAssertEqual(mappedObject.dictAnyObject[key]! as! String, value, "AnyObject Dictionary failed")
+			XCTAssertEqual(mappedObject.dictAnyObjectOptional![key]! as! String, value, "Optional AnyObject Dictionary failed")
+			XCTAssertEqual(mappedObject.dictAnyObjectImplicitlyUnwrapped[key]! as! String, value, "Implicity unwrapped optional AnyObject Dictionary failed")
 		} else {
 			XCTAssert(false, "String Dictionary to JSON failed")
 		}
@@ -388,12 +388,12 @@ class BasicTypesTestsToJSON: XCTestCase {
 		
 		let json = Mapper<TestCollectionOfPrimitives>().toJSON(object)
 		
-		XCTAssertTrue((json["dictStringString"] as [String:String]).count == 1)
-		XCTAssertTrue((json["dictStringBool"] as [String:Bool]).count == 1)
-		XCTAssertTrue((json["dictStringInt"] as [String:Int]).count == 1)
-		XCTAssertTrue((json["dictStringDouble"] as [String:Double]).count == 1)
-		XCTAssertTrue((json["dictStringFloat"] as [String:Float]).count == 1)
-		let dict:[String: String] = json["dictStringString"] as [String:String]
+		XCTAssertTrue((json["dictStringString"] as! [String:String]).count == 1)
+		XCTAssertTrue((json["dictStringBool"] as! [String:Bool]).count == 1)
+		XCTAssertTrue((json["dictStringInt"] as! [String:Int]).count == 1)
+		XCTAssertTrue((json["dictStringDouble"] as! [String:Double]).count == 1)
+		XCTAssertTrue((json["dictStringFloat"] as! [String:Float]).count == 1)
+		let dict:[String: String] = json["dictStringString"] as! [String:String]
 		let value = dict["string"]! as String
 		XCTAssertTrue(value == "string")
 	}

--- a/ObjectMapperTests/CustomTransformTests.swift
+++ b/ObjectMapperTests/CustomTransformTests.swift
@@ -72,7 +72,7 @@ class CustomTransformTests: XCTestCase {
 		
 		let JSONOutput = mapper.toJSON(transform)
 		
-		XCTAssert(JSONOutput["customFormateDate"]! as String == dateString, "CustomFormatDateTransform failed")
+		XCTAssert(JSONOutput["customFormateDate"]! as! String == dateString, "CustomFormatDateTransform failed")
 	}
 	
 	func testIntToStringTransformOf() {

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -332,20 +332,20 @@ class ObjectMapperTests: XCTestCase {
 		let JSONArray = Mapper().toJSONArray(taskArray)
 		println(JSONArray)
 		
-		let taskId1 = JSONArray[0]["taskId"] as Int
-		let percentage1 = JSONArray[0]["percentage"] as Double
+		let taskId1 = JSONArray[0]["taskId"] as! Int
+		let percentage1 = JSONArray[0]["percentage"] as! Double
 		
 		XCTAssertEqual(taskId1, task1.taskId!, "TaskId1 was not mapped correctly")
 		XCTAssertEqual(percentage1, task1.percentage!, "percentage1 was not mapped correctly")
 
-		let taskId2 = JSONArray[1]["taskId"] as Int
-		let percentage2 = JSONArray[1]["percentage"] as Double
+		let taskId2 = JSONArray[1]["taskId"] as! Int
+		let percentage2 = JSONArray[1]["percentage"] as! Double
 		
 		XCTAssertEqual(taskId2, task2.taskId!, "TaskId2 was not mapped correctly")
 		XCTAssertEqual(percentage2, task2.percentage!, "percentage2 was not mapped correctly")
 		
-		let taskId3 = JSONArray[2]["taskId"] as Int
-		let percentage3 = JSONArray[2]["percentage"] as Double
+		let taskId3 = JSONArray[2]["taskId"] as! Int
+		let percentage3 = JSONArray[2]["percentage"] as! Double
 		
 		XCTAssertEqual(taskId3, task3.taskId!, "TaskId3 was not mapped correctly")
 		XCTAssertEqual(percentage3, task3.percentage!, "percentage3 was not mapped correctly")


### PR DESCRIPTION
A couple of minor changes are required to build the framework and tests against Swift 1.2 and Xcode 6.3. I'm not sure what the Swift 1.2 plan is for ObjectMapper, but at the very least, a branch might be nice?