### PR TITLE
Add a white space between custom operator and generics

### DIFF
--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -22,7 +22,7 @@ import Foundation
 /**
 * Object of Basic type
 */
-public func <=<T>(inout left: T, right: Map) {
+public func <= <T>(inout left: T, right: Map) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().basicType(&left, object: right.currentValue)
     } else {
@@ -33,7 +33,7 @@ public func <=<T>(inout left: T, right: Map) {
 /**
 * Optional object of basic type
 */
-public func <=<T>(inout left: T?, right: Map) {
+public func <= <T>(inout left: T?, right: Map) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().optionalBasicType(&left, object: right.currentValue)
     } else {
@@ -44,7 +44,7 @@ public func <=<T>(inout left: T?, right: Map) {
 /**
 * Implicitly unwrapped optional object of basic type
 */
-public func <=<T>(inout left: T!, right: Map) {
+public func <= <T>(inout left: T!, right: Map) {
 	if right.mappingType == MappingType.fromJSON {
 		FromJSON<T>().optionalBasicType(&left, object: right.currentValue)
 	} else {
@@ -55,7 +55,7 @@ public func <=<T>(inout left: T!, right: Map) {
 /**
 * Object of Basic type with Transform
 */
-public func <=<T, Transform: TransformType where Transform.Object == T>(inout left: T, right: (Map, Transform)) {
+public func <= <T, Transform: TransformType where Transform.Object == T>(inout left: T, right: (Map, Transform)) {
     if right.0.mappingType == MappingType.fromJSON {
         var value: T? = right.1.transformFromJSON(right.0.currentValue)
         FromJSON<T>().basicType(&left, object: value)
@@ -68,7 +68,7 @@ public func <=<T, Transform: TransformType where Transform.Object == T>(inout le
 /**
 * Optional object of basic type with Transform
 */
-public func <=<T, Transform: TransformType where Transform.Object == T>(inout left: T?, right: (Map, Transform)) {
+public func <= <T, Transform: TransformType where Transform.Object == T>(inout left: T?, right: (Map, Transform)) {
     if right.0.mappingType == MappingType.fromJSON {
         var value: T? = right.1.transformFromJSON(right.0.currentValue)
         FromJSON<T>().optionalBasicType(&left, object: value)
@@ -81,7 +81,7 @@ public func <=<T, Transform: TransformType where Transform.Object == T>(inout le
 /**
 * Implicitly unwrapped optional object of basic type with Transform
 */
-public func <=<T, Transform: TransformType where Transform.Object == T>(inout left: T!, right: (Map, Transform)) {
+public func <= <T, Transform: TransformType where Transform.Object == T>(inout left: T!, right: (Map, Transform)) {
 	if right.0.mappingType == MappingType.fromJSON {
 		var value: T? = right.1.transformFromJSON(right.0.currentValue)
 		FromJSON<T>().optionalBasicType(&left, object: value)
@@ -95,7 +95,7 @@ public func <=<T, Transform: TransformType where Transform.Object == T>(inout le
 /**
 * Array of objects with Basic types
 */
-public func <=(inout left: Array<AnyObject>, right: Map) {
+public func <= (inout left: Array<AnyObject>, right: Map) {
 	if right.mappingType == MappingType.fromJSON {
 		FromJSON<AnyObject>().basicType(&left, object: right.currentValue)
 	} else {
@@ -106,7 +106,7 @@ public func <=(inout left: Array<AnyObject>, right: Map) {
 /**
 * Optional array of objects with Basic type
 */
-public func <=(inout left: Array<AnyObject>?, right: Map) {
+public func <= (inout left: Array<AnyObject>?, right: Map) {
 	if right.mappingType == MappingType.fromJSON {
 		FromJSON<AnyObject>().optionalBasicType(&left, object: right.currentValue)
 	} else {
@@ -117,7 +117,7 @@ public func <=(inout left: Array<AnyObject>?, right: Map) {
 /**
 * Implicitly unwrapped optional array of objects with Basic type
 */
-public func <=(inout left: Array<AnyObject>!, right: Map) {
+public func <= (inout left: Array<AnyObject>!, right: Map) {
 	if right.mappingType == MappingType.fromJSON {
 		FromJSON<AnyObject>().optionalBasicType(&left, object: right.currentValue)
 	} else {
@@ -129,7 +129,7 @@ public func <=(inout left: Array<AnyObject>!, right: Map) {
 /**
 * Dictionary of objects with Basic type
 */
-public func <=(inout left: Dictionary<String, AnyObject>, right: Map) {
+public func <= (inout left: Dictionary<String, AnyObject>, right: Map) {
 	if right.mappingType == MappingType.fromJSON {
 		FromJSON<AnyObject>().basicType(&left, object: right.currentValue)
 	} else {
@@ -140,7 +140,7 @@ public func <=(inout left: Dictionary<String, AnyObject>, right: Map) {
 /**
 * Optional dictionary of objects with Basic type <String, AnyObject>
 */
-public func <=(inout left: Dictionary<String, AnyObject>?, right: Map) {
+public func <= (inout left: Dictionary<String, AnyObject>?, right: Map) {
 	if right.mappingType == MappingType.fromJSON {
 		FromJSON<AnyObject>().optionalBasicType(&left, object: right.currentValue)
 	} else {
@@ -151,7 +151,7 @@ public func <=(inout left: Dictionary<String, AnyObject>?, right: Map) {
 /**
 * Implicitly unwrapped optional dictionary of objects with Basic type <String, AnyObject>
 */
-public func <=(inout left: Dictionary<String, AnyObject>!, right: Map) {
+public func <= (inout left: Dictionary<String, AnyObject>!, right: Map) {
 	if right.mappingType == MappingType.fromJSON {
 		FromJSON<AnyObject>().optionalBasicType(&left, object: right.currentValue)
 	} else {
@@ -163,7 +163,7 @@ public func <=(inout left: Dictionary<String, AnyObject>!, right: Map) {
 /**
 * Object conforming to Mappable
 */
-public func <=<T: Mappable>(inout left: T, right: Map) {
+public func <= <T: Mappable>(inout left: T, right: Map) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().object(&left, object: right.currentValue)
     } else {
@@ -174,7 +174,7 @@ public func <=<T: Mappable>(inout left: T, right: Map) {
 /**
 * Optional Mappable objects
 */
-public func <=<T: Mappable>(inout left: T?, right: Map) {
+public func <= <T: Mappable>(inout left: T?, right: Map) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().optionalObject(&left, object: right.currentValue)
     } else {
@@ -185,7 +185,7 @@ public func <=<T: Mappable>(inout left: T?, right: Map) {
 /**
 * Implicitly unwrapped optional Mappable objects
 */
-public func <=<T: Mappable>(inout left: T!, right: Map) {
+public func <= <T: Mappable>(inout left: T!, right: Map) {
 	if right.mappingType == MappingType.fromJSON {
 		FromJSON<T>().optionalObject(&left, object: right.currentValue)
 	} else {
@@ -197,7 +197,7 @@ public func <=<T: Mappable>(inout left: T!, right: Map) {
 /**
 * Dictionary of Mappable objects <String, T: Mappable>
 */
-public func <=<T: Mappable>(inout left: Dictionary<String, T>, right: Map) {
+public func <= <T: Mappable>(inout left: Dictionary<String, T>, right: Map) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().objectDictionary(&left, object: right.currentValue)
     } else {
@@ -208,7 +208,7 @@ public func <=<T: Mappable>(inout left: Dictionary<String, T>, right: Map) {
 /**
 * Optional Dictionary of Mappable object <String, T: Mappable>
 */
-public func <=<T: Mappable>(inout left: Dictionary<String, T>?, right: Map) {
+public func <= <T: Mappable>(inout left: Dictionary<String, T>?, right: Map) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().optionalObjectDictionary(&left, object: right.currentValue)
     } else {
@@ -219,7 +219,7 @@ public func <=<T: Mappable>(inout left: Dictionary<String, T>?, right: Map) {
 /**
 * Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable>
 */
-public func <=<T: Mappable>(inout left: Dictionary<String, T>!, right: Map) {
+public func <= <T: Mappable>(inout left: Dictionary<String, T>!, right: Map) {
 	if right.mappingType == MappingType.fromJSON {
 		FromJSON<T>().optionalObjectDictionary(&left, object: right.currentValue)
 	} else {
@@ -231,7 +231,7 @@ public func <=<T: Mappable>(inout left: Dictionary<String, T>!, right: Map) {
 /**
 * Array of Mappable objects
 */
-public func <=<T: Mappable>(inout left: Array<T>, right: Map) {
+public func <= <T: Mappable>(inout left: Array<T>, right: Map) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().objectArray(&left, object: right.currentValue)
     } else {
@@ -242,7 +242,7 @@ public func <=<T: Mappable>(inout left: Array<T>, right: Map) {
 /**
 * Optional array of Mappable objects
 */
-public func <=<T: Mappable>(inout left: Array<T>?, right: Map) {
+public func <= <T: Mappable>(inout left: Array<T>?, right: Map) {
     if right.mappingType == MappingType.fromJSON {
         FromJSON<T>().optionalObjectArray(&left, object: right.currentValue)
     } else {
@@ -253,7 +253,7 @@ public func <=<T: Mappable>(inout left: Array<T>?, right: Map) {
 /**
 * Implicitly unwrapped Optional array of Mappable objects
 */
-public func <=<T: Mappable>(inout left: Array<T>!, right: Map) {
+public func <= <T: Mappable>(inout left: Array<T>!, right: Map) {
 	if right.mappingType == MappingType.fromJSON {
 		FromJSON<T>().optionalObjectArray(&left, object: right.currentValue)
 	} else {


### PR DESCRIPTION
I'm really impressed by this repository and use this in my Swift project. Thank you.

I think that code like below is a little bit not readable
the operator is <=? or <=< ?
```
public func <=<T>(inout left: T, right: Map) {
```

So I added a whitespace after custom operator.

If you would like, please merge this...

Sorry for sending such a simple and ridiculous change.

Thank you.