### PR TITLE
Symetric mappings for nested keys

### DIFF
--- a/ObjectMapper/Core/ToJSON.swift
+++ b/ObjectMapper/Core/ToJSON.swift
@@ -11,8 +11,20 @@ import Foundation
 class ToJSON {
 	
     func basicType<N>(field: N, key: String, inout dictionary: [String : AnyObject]) {
-		var temp = dictionary
 		var currentKey = key
+
+		// Nested keys
+		var allKeys = currentKey.componentsSeparatedByString(".")
+		if allKeys.count > 1 {
+			currentKey = allKeys.first!
+			allKeys.removeAtIndex(0)
+			let remainingKey = join(".", allKeys)
+
+			var innerDictionary : [String : AnyObject] = [:]
+			basicType(field, key: remainingKey, dictionary: &innerDictionary)
+			dictionary[currentKey] = innerDictionary
+			return
+		}
 
         switch field {
         // basic Types

--- a/ObjectMapper/Core/ToJSON.swift
+++ b/ObjectMapper/Core/ToJSON.swift
@@ -14,11 +14,10 @@ class ToJSON {
 		var currentKey = key
 
 		// Nested keys
-		var allKeys = currentKey.componentsSeparatedByString(".")
+		let allKeys = currentKey.componentsSeparatedByString(".")
 		if allKeys.count > 1 {
 			currentKey = allKeys.first!
-			allKeys.removeAtIndex(0)
-			let remainingKey = join(".", allKeys)
+			let remainingKey = join(".", Array(allKeys[1..<allKeys.count]))
 
 			var innerDictionary : [String : AnyObject] = [:]
 			basicType(field, key: remainingKey, dictionary: &innerDictionary)

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -158,9 +158,19 @@ class ObjectMapperTests: XCTestCase {
 		let heightInCM = 180.0
 		
 		let userJSONString = "{\"username\":\"bob\", \"height\": {\"value\": \(heightInCM), \"text\": \"6 feet tall\"} }"
-		
+
+		// Test that a nested JSON can be mapped to an object
 		if let user = userMapper.map(string: userJSONString) {
 			XCTAssertEqual(user.heightInCM!, heightInCM, "Username should be the same")
+
+			// Test that nested keys can be mapped to JSON
+			let userJSONString = userMapper.toJSONString(user, prettyPrint: true)
+
+			if let user = userMapper.map(string: userJSONString) {
+				XCTAssertEqual(user.heightInCM!, heightInCM, "Username should be the same")
+			} else {
+				XCTAssert(false, "Nested key failed")
+			}
 		} else {
 			XCTAssert(false, "Nested key failed")
 		}

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -161,13 +161,13 @@ class ObjectMapperTests: XCTestCase {
 
 		// Test that a nested JSON can be mapped to an object
 		if let user = userMapper.map(string: userJSONString) {
-			XCTAssertEqual(user.heightInCM!, heightInCM, "Username should be the same")
+			XCTAssertEqual(user.heightInCM!, heightInCM, "Height should be the same")
 
 			// Test that nested keys can be mapped to JSON
 			let userJSONString = userMapper.toJSONString(user, prettyPrint: true)
 
 			if let user = userMapper.map(string: userJSONString) {
-				XCTAssertEqual(user.heightInCM!, heightInCM, "Username should be the same")
+				XCTAssertEqual(user.heightInCM!, heightInCM, "Height should be the same")
 			} else {
 				XCTAssert(false, "Nested key failed")
 			}


### PR DESCRIPTION
Nested keys like below work well for mapping JSON into an object

```swift
heightInCM <- map["height.value"]
```

It, however, doesn't work for mapping an object into JSON
```js
{
  "height.value" : 180,
}
```

An expected result is
```js
{
  "height" :  {
    "value" : 180
  }
}
```