### PR TITLE
Fix redundant mapping call at subclasses in test target

### DIFF
--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -738,7 +738,6 @@ class Subclass: Base {
 	
 	required init?(_ map: Map) {
 		super.init(map)
-		mapping(map)
 	}
 
 	override func mapping(map: Map) {
@@ -759,7 +758,6 @@ class GenericSubclass<T>: Base {
 
 	required init?(_ map: Map) {
 		super.init(map)
-		mapping(map)
 	}
 
 	override func mapping(map: Map) {


### PR DESCRIPTION
Superclass's `mapping` call in `init?` correctly calls subclass's implementation.

Addresses https://github.com/Hearst-DD/ObjectMapper/pull/71#issuecomment-77635985.