### PR TITLE
adding a custom date format transform class

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		37AFD9B91AAD191C00AB59B5 /* CustomDateFormatTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */; };
 		6A3774341A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3774331A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift */; };
 		6A6AEB961A93874F002573D3 /* BasicTypesTestsFromJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6AEB951A93874F002573D3 /* BasicTypesTestsFromJSON.swift */; };
 		6A6AEB981A9387D0002573D3 /* BasicTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6AEB971A9387D0002573D3 /* BasicTypes.swift */; };
@@ -34,6 +35,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomDateFormatTransform.swift; sourceTree = "<group>"; };
 		6A3774331A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BasicTypesTestsToJSON.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6A6AEB951A93874F002573D3 /* BasicTypesTestsFromJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicTypesTestsFromJSON.swift; sourceTree = "<group>"; };
 		6A6AEB971A9387D0002573D3 /* BasicTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicTypes.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				CD71C8C01A7218AD009D4161 /* TransformOf.swift */,
 				CD50B6FC1A82518300744312 /* TransformType.swift */,
 				6A6C54CF19FE8DB600239454 /* URLTransform.swift */,
+				37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */,
 			);
 			path = Transforms;
 			sourceTree = "<group>";
@@ -260,6 +263,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				37AFD9B91AAD191C00AB59B5 /* CustomDateFormatTransform.swift in Sources */,
 				CD50B6FD1A82518300744312 /* TransformType.swift in Sources */,
 				6AAC8FD319F048FE00E7A677 /* DateTransform.swift in Sources */,
 				D86BDEA41A51E5AD00120819 /* ISO8601DateTransform.swift in Sources */,

--- a/ObjectMapper/Transforms/CustomDateFormatTransform.swift
+++ b/ObjectMapper/Transforms/CustomDateFormatTransform.swift
@@ -1,0 +1,43 @@
+//
+//  CustomDateFormatTransform.swift
+//  ObjectMapper
+//
+//  Created by Dan McCracken on 3/8/15.
+//
+//
+
+import Foundation
+
+public class CustomDateFormatTransform: TransformType {
+    public typealias Object = NSDate
+    public typealias JSON = String
+    
+    let formatString: String = ""
+
+    public init(formatString: String) {
+        if !formatString.isEmpty {
+            self.formatString = formatString
+        }
+    }
+
+	private lazy var dateFormatter: NSDateFormatter = {
+		let formatter = NSDateFormatter()
+		formatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+		formatter.dateFormat = self.formatString
+		return formatter
+	}()
+
+	public func transformFromJSON(value: AnyObject?) -> NSDate? {
+		if let dateString = value as? String {
+			return dateFormatter.dateFromString(dateString)
+		}
+		return nil
+	}
+
+	public func transformToJSON(value: NSDate?) -> String? {
+		if let date = value {
+			return dateFormatter.stringFromDate(date)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
Much like the ISO8601 transform, this class simply takes in the desired date format as an initializer and then attempts to map the json date to an NSDate.

My first experience with this library and I had to deal with an API sending in a date like "2015-03-03T02:36:44" which didn't parse for the ISO8601 transform since its missing time zone locale.  This new class allowed me to setup my mapping like below, and get the desired NSDate.

```
startDate <- (map["startDate"], CustomDateFormatTransform(formatString: "yyyy-MM-dd'T'HH:mm:ss"))
```


This seems like a really useful/common override of the transform mapping, so I thought I'd see what you thought about adding it!

Thanks for considering.