### PR TITLE
Workaround swift crash with nested mappings

### DIFF
--- a/ObjectMapper/Core/ToJSON.swift
+++ b/ObjectMapper/Core/ToJSON.swift
@@ -22,10 +22,13 @@ private func setValue(value: AnyObject, forKeyPathComponents components: [String
 	if components.count == 1 {
 		return dictionary[head] = value
 	} else {
-		var child = (dictionary[head] as? [String : AnyObject]) ?? [:]
+		var child = (dictionary[head] as? [String : AnyObject])
+		if child == nil {
+			child = [:]
+		}
 
 		let tail = Array(components[1..<components.count])
-		setValue(value, forKeyPathComponents: tail, dictionary: &child)
+		setValue(value, forKeyPathComponents: tail, dictionary: &child!)
 
 		return dictionary[head] = child
 	}


### PR DESCRIPTION
The nested mapping code is crashing for us on ToJson.swift:30 when using multiple nested values like so:
first <- map["a.b"]
second <- map["a.c"]

The crash happens in ToJson.swift setValue on the second <- call, when it is referencing/reusing the nested 'a' dictionary. This appears (to my best guess, swift newbie!) to be a bug in the swift compiler and the nil coalescing operator.

The pull request rewrites this code slightly to workaround the problem.

The issue oddly only occurs on Release and not Debug builds.
To demonstrate the issue, change the ObjectMapper-iOS scheme to Test Build Configuration "Release" and run the ObjectMapper-iOSTests.

XCode 6.2 / Swift 1.1.

Isolated test case is in this gist: https://gist.github.com/barnybug/cc7b717387474bea18ac
