### PR TITLE
Remove AnyObject variants of `basicType` in `FromJSON`

### DIFF
--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -9,26 +9,26 @@
 internal final class FromJSON {
 	
 	/// Basic type
-    class func basicType<FieldType>(inout field: FieldType, object: FieldType?) {
-        if let value = object {
-            field = value
-        }
-    }
-	
+	class func basicType<FieldType>(inout field: FieldType, object: FieldType?) {
+		if let value = object {
+			field = value
+		}
+	}
+
 	/// optional basic type
-    class func optionalBasicType<FieldType>(inout field: FieldType?, object: FieldType?) {
-        if let value = object {
-            field = value
-        }
-    }
-	
+	class func optionalBasicType<FieldType>(inout field: FieldType?, object: FieldType?) {
+		if let value = object {
+			field = value
+		}
+	}
+
 	/// Implicitly unwrapped optional basic type
 	class func optionalBasicType<FieldType>(inout field: FieldType!, object: FieldType?) {
 		if let value = object {
 			field = value
 		}
 	}
-	
+
 	/// Mappable object
 	class func object<N: Mappable>(inout field: N, object: AnyObject?) {
 		if let value: N = Mapper().map(object) {

--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -9,10 +9,6 @@
 internal final class FromJSON {
 	
 	/// Basic type
-    class func basicType<FieldType>(inout field: FieldType, object: AnyObject?) {
-        basicType(&field, object: object as? FieldType)
-    }
-	
     class func basicType<FieldType>(inout field: FieldType, object: FieldType?) {
         if let value = object {
             field = value
@@ -20,23 +16,15 @@ internal final class FromJSON {
     }
 	
 	/// optional basic type
-    class func optionalBasicType<FieldType>(inout field: FieldType?, object: AnyObject?) {
-		optionalBasicType(&field, object: object as? FieldType)
-    }
-	
     class func optionalBasicType<FieldType>(inout field: FieldType?, object: FieldType?) {
-        if let value: FieldType = object {
+        if let value = object {
             field = value
         }
     }
 	
 	/// Implicitly unwrapped optional basic type
-	class func optionalBasicType<FieldType>(inout field: FieldType!, object: AnyObject?) {
-		optionalBasicType(&field, object: object as? FieldType)
-	}
-	
 	class func optionalBasicType<FieldType>(inout field: FieldType!, object: FieldType?) {
-		if let value: FieldType = object {
+		if let value = object {
 			field = value
 		}
 	}

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -21,7 +21,7 @@ infix operator <- {}
 
 public func <- <T>(inout left: T, right: Map) {
     if right.mappingType == MappingType.fromJSON {
-        FromJSON.basicType(&left, object: right.currentValue)
+        FromJSON.basicType(&left, object: right.value())
     } else {
         ToJSON.basicType(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
     }
@@ -32,7 +32,7 @@ public func <- <T>(inout left: T, right: Map) {
 */
 public func <- <T>(inout left: T?, right: Map) {
     if right.mappingType == MappingType.fromJSON {
-        FromJSON.optionalBasicType(&left, object: right.currentValue)
+        FromJSON.optionalBasicType(&left, object: right.value())
     } else {
         ToJSON.optionalBasicType(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
     }
@@ -43,7 +43,7 @@ public func <- <T>(inout left: T?, right: Map) {
 */
 public func <- <T>(inout left: T!, right: Map) {
 	if right.mappingType == MappingType.fromJSON {
-		FromJSON.optionalBasicType(&left, object: right.currentValue)
+		FromJSON.optionalBasicType(&left, object: right.value())
 	} else {
 		ToJSON.optionalBasicType(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
 	}


### PR DESCRIPTION
Changed to just cast a value to `FieldType` in operators.