### PR TITLE
Fix method parameter of sample code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ let user = Mapper<User>().map(JSONString)
 
 Convert a model object to a JSON string:
 ```swift
-let JSONString = Mapper().toJSONString(user)
+let JSONString = Mapper().toJSONString(user, prettyPrint: true)
 ```
 
 Object mapper can map classes composed of the following types:


### PR DESCRIPTION
```
let JSONString = Mapper().toJSONString(user)
```

The above code written in README cannot be compiled because `prettyPrint` parameter was added to `toJSONString` method in this commit https://github.com/Hearst-DD/ObjectMapper/commit/f501c684ef6333df84966484b5343f67ba5244ba#diff-a9498ca83904e6eb2c05ea55fe3c5a1dR104 .