### PR TITLE
Enum (RawRepresentable)  objects mapping

### DIFF
--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -53,9 +53,7 @@ internal final class FromJSON {
 	/// Array of Raw representable
 	class func rawRepresentableArray<N: RawRepresentable>(inout field: [N], object: [N.RawValue]?) {
 		if let values = object {
-			field = values.reduce([N]()) { (var vs, v) in
-				vs.append(N(rawValue: v)!)
-				return vs
+			field = values.map { (v: N.RawValue) in	N(rawValue: v)!	}
 		}
 	}
 

--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -50,6 +50,16 @@ internal final class FromJSON {
 		}
 	}
 
+	/// Array of Raw representable
+	class func rawRepresentableArray<N: RawRepresentable>(inout field: [N], object: [N.RawValue]?) {
+		if let values = object {
+			field = values.reduce([N]()) { (var vs, v) in
+				vs.append(N(rawValue: v)!)
+				return vs
+			}
+		}
+	}
+
 	/// Mappable object
 	class func object<N: Mappable>(inout field: N, object: AnyObject?) {
 		if let value: N = Mapper().map(object) {

--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -29,6 +29,27 @@ internal final class FromJSON {
 		}
 	}
 
+	/// Raw representable
+	class func rawRepresentable<N: RawRepresentable>(inout field: N, object: N.RawValue?) {
+		if let value = object {
+			field = N(rawValue: value)!
+		}
+	}
+
+	/// Optional raw representable
+	class func rawRepresentable<N: RawRepresentable>(inout field: N?, object: N.RawValue?) {
+		if let value = object {
+			field = N(rawValue: value)
+		}
+	}
+
+	/// Implicitly unwrapped optional basic type
+	class func rawRepresentable<N: RawRepresentable>(inout field: N!, object: N.RawValue?) {
+		if let value = object {
+			field = N(rawValue: value)
+		}
+	}
+
 	/// Mappable object
 	class func object<N: Mappable>(inout field: N, object: AnyObject?) {
 		if let value: N = Mapper().map(object) {

--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -57,8 +57,46 @@ internal final class FromJSON {
 		}
 	}
 
+	/// Array of Raw representable
+	class func rawRepresentableArray<N: RawRepresentable>(inout field: [N]?, object: [N.RawValue]?) {
+		if let values = object {
+			field = values.map { (v: N.RawValue) in	N(rawValue: v)!	}
+		}
+	}
+
+	/// Array of Raw representable
+	class func rawRepresentableArray<N: RawRepresentable>(inout field: [N]!, object: [N.RawValue]?) {
+		if let values = object {
+			field = values.map { (v: N.RawValue) in	N(rawValue: v)!	}
+		}
+	}
+
 	/// Dictionary of Raw representable
 	class func rawRepresentableDict<N: RawRepresentable>(inout field: [String: N], object: [String: N.RawValue]?) {
+		if let values = object {
+			field = map(values) { (k: String, v: N.RawValue) in	(k, N(rawValue: v)!) }
+				.reduce([:]) { (var d, e) in
+					let (k, v) = e
+					d[k] = v
+					return d
+			}
+		}
+	}
+
+	/// Dictionary of Raw representable
+	class func rawRepresentableDict<N: RawRepresentable>(inout field: [String: N]?, object: [String: N.RawValue]?) {
+		if let values = object {
+			field = map(values) { (k: String, v: N.RawValue) in	(k, N(rawValue: v)!) }
+				.reduce([:]) { (var d, e) in
+					var (k, v) = e
+					d?[k] = v
+					return d
+			}
+		}
+	}
+
+	/// Dictionary of Raw representable
+	class func rawRepresentableDict<N: RawRepresentable>(inout field: [String: N]!, object: [String: N.RawValue]?) {
 		if let values = object {
 			field = map(values) { (k: String, v: N.RawValue) in	(k, N(rawValue: v)!) }
 				.reduce([:]) { (var d, e) in

--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -56,6 +56,17 @@ internal final class FromJSON {
 			field = values.reduce([N]()) { (var vs, v) in
 				vs.append(N(rawValue: v)!)
 				return vs
+		}
+	}
+
+	/// Dictionary of Raw representable
+	class func rawRepresentableDict<N: RawRepresentable>(inout field: [String: N], object: [String: N.RawValue]?) {
+		if let values = object {
+			field = map(values) { (k: String, v: N.RawValue) in	(k, N(rawValue: v)!) }
+				.reduce([:]) { (var d, e) in
+					let (k, v) = e
+					d[k] = v
+					return d
 			}
 		}
 	}

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -83,6 +83,17 @@ public func <- <T: RawRepresentable>(inout left: T!, right: Map) {
 }
 
 /**
+* Array of Raw Representable object
+*/
+public func <- <T: RawRepresentable>(inout left: [T], right: Map) {
+	if right.mappingType == MappingType.FromJSON {
+		FromJSON.rawRepresentableArray(&left, object: right.value())
+	} else {
+		// TODO:
+	}
+}
+
+/**
 * Object of Basic type with Transform
 */
 public func <- <T, Transform: TransformType where Transform.Object == T>(inout left: T, right: (Map, Transform)) {

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -94,9 +94,53 @@ public func <- <T: RawRepresentable>(inout left: [T], right: Map) {
 }
 
 /**
+* Array of Raw Representable object
+*/
+public func <- <T: RawRepresentable>(inout left: [T]?, right: Map) {
+	if right.mappingType == MappingType.FromJSON {
+		FromJSON.rawRepresentableArray(&left, object: right.value())
+	} else {
+		// TODO:
+	}
+}
+
+/**
+* Array of Raw Representable object
+*/
+public func <- <T: RawRepresentable>(inout left: [T]!, right: Map) {
+	if right.mappingType == MappingType.FromJSON {
+		FromJSON.rawRepresentableArray(&left, object: right.value())
+	} else {
+		// TODO:
+	}
+}
+
+/**
 * Dictionary of Raw Representable object
 */
 public func <- <T: RawRepresentable>(inout left: [String: T], right: Map) {
+	if right.mappingType == MappingType.FromJSON {
+		FromJSON.rawRepresentableDict(&left, object: right.value())
+	} else {
+		// TODO:
+	}
+}
+
+/**
+* Dictionary of Raw Representable object
+*/
+public func <- <T: RawRepresentable>(inout left: [String: T]?, right: Map) {
+	if right.mappingType == MappingType.FromJSON {
+		FromJSON.rawRepresentableDict(&left, object: right.value())
+	} else {
+		// TODO:
+	}
+}
+
+/**
+* Dictionary of Raw Representable object
+*/
+public func <- <T: RawRepresentable>(inout left: [String: T]!, right: Map) {
 	if right.mappingType == MappingType.FromJSON {
 		FromJSON.rawRepresentableDict(&left, object: right.value())
 	} else {

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -56,7 +56,7 @@ public func <- <T: RawRepresentable>(inout left: T, right: Map) {
 	if right.mappingType == MappingType.FromJSON {
 		FromJSON.rawRepresentable(&left, object: right.value())
 	} else {
-		// TODO: 
+		ToJSON.rawRepresentable(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
 	}
 }
 
@@ -67,7 +67,7 @@ public func <- <T: RawRepresentable>(inout left: T?, right: Map) {
 	if right.mappingType == MappingType.FromJSON {
 		FromJSON.rawRepresentable(&left, object: right.value())
 	} else {
-		// TODO:
+		ToJSON.rawRepresentable(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
 	}
 }
 
@@ -78,7 +78,7 @@ public func <- <T: RawRepresentable>(inout left: T!, right: Map) {
 	if right.mappingType == MappingType.FromJSON {
 		FromJSON.rawRepresentable(&left, object: right.value())
 	} else {
-		// TODO:
+		ToJSON.rawRepresentable(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
 	}
 }
 

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -94,6 +94,17 @@ public func <- <T: RawRepresentable>(inout left: [T], right: Map) {
 }
 
 /**
+* Dictionary of Raw Representable object
+*/
+public func <- <T: RawRepresentable>(inout left: [String: T], right: Map) {
+	if right.mappingType == MappingType.FromJSON {
+		FromJSON.rawRepresentableDict(&left, object: right.value())
+	} else {
+		// TODO:
+	}
+}
+
+/**
 * Object of Basic type with Transform
 */
 public func <- <T, Transform: TransformType where Transform.Object == T>(inout left: T, right: (Map, Transform)) {

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -50,6 +50,39 @@ public func <- <T>(inout left: T!, right: Map) {
 }
 
 /**
+* Object of Raw Representable type
+*/
+public func <- <T: RawRepresentable>(inout left: T, right: Map) {
+	if right.mappingType == MappingType.FromJSON {
+		FromJSON.rawRepresentable(&left, object: right.value())
+	} else {
+		// TODO: 
+	}
+}
+
+/**
+* Optional Object of Raw Representable type
+*/
+public func <- <T: RawRepresentable>(inout left: T?, right: Map) {
+	if right.mappingType == MappingType.FromJSON {
+		FromJSON.rawRepresentable(&left, object: right.value())
+	} else {
+		// TODO:
+	}
+}
+
+/**
+* Implicitly Unwrapped Optional Object of Raw Representable type
+*/
+public func <- <T: RawRepresentable>(inout left: T!, right: Map) {
+	if right.mappingType == MappingType.FromJSON {
+		FromJSON.rawRepresentable(&left, object: right.value())
+	} else {
+		// TODO:
+	}
+}
+
+/**
 * Object of Basic type with Transform
 */
 public func <- <T, Transform: TransformType where Transform.Object == T>(inout left: T, right: (Map, Transform)) {

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -89,7 +89,7 @@ public func <- <T: RawRepresentable>(inout left: [T], right: Map) {
 	if right.mappingType == MappingType.FromJSON {
 		FromJSON.rawRepresentableArray(&left, object: right.value())
 	} else {
-		// TODO:
+		ToJSON.rawRepresentableArray(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
 	}
 }
 
@@ -100,7 +100,7 @@ public func <- <T: RawRepresentable>(inout left: [T]?, right: Map) {
 	if right.mappingType == MappingType.FromJSON {
 		FromJSON.rawRepresentableArray(&left, object: right.value())
 	} else {
-		// TODO:
+		ToJSON.rawRepresentableArray(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
 	}
 }
 
@@ -111,7 +111,7 @@ public func <- <T: RawRepresentable>(inout left: [T]!, right: Map) {
 	if right.mappingType == MappingType.FromJSON {
 		FromJSON.rawRepresentableArray(&left, object: right.value())
 	} else {
-		// TODO:
+		ToJSON.rawRepresentableArray(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
 	}
 }
 
@@ -122,7 +122,7 @@ public func <- <T: RawRepresentable>(inout left: [String: T], right: Map) {
 	if right.mappingType == MappingType.FromJSON {
 		FromJSON.rawRepresentableDict(&left, object: right.value())
 	} else {
-		// TODO:
+		ToJSON.rawRepresentableDict(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
 	}
 }
 
@@ -133,7 +133,7 @@ public func <- <T: RawRepresentable>(inout left: [String: T]?, right: Map) {
 	if right.mappingType == MappingType.FromJSON {
 		FromJSON.rawRepresentableDict(&left, object: right.value())
 	} else {
-		// TODO:
+		ToJSON.rawRepresentableDict(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
 	}
 }
 
@@ -144,7 +144,7 @@ public func <- <T: RawRepresentable>(inout left: [String: T]!, right: Map) {
 	if right.mappingType == MappingType.FromJSON {
 		FromJSON.rawRepresentableDict(&left, object: right.value())
 	} else {
-		// TODO:
+		ToJSON.rawRepresentableDict(left, key: right.currentKey!, dictionary: &right.JSONDictionary)
 	}
 }
 

--- a/ObjectMapper/Core/ToJSON.swift
+++ b/ObjectMapper/Core/ToJSON.swift
@@ -109,6 +109,32 @@ internal final class ToJSON {
 			}
 	  }
 
+	class func rawRepresentableArray<N: RawRepresentable>(field: [N], key: String, inout dictionary: [String : AnyObject]) {
+		basicType(field.map { e in e.rawValue }, key: key, dictionary: &dictionary)
+	}
+
+	class func rawRepresentableArray<N: RawRepresentable>(field: [N]?, key: String, inout dictionary: [String : AnyObject]) {
+		if let field = field {
+			rawRepresentableArray(field, key: key, dictionary: &dictionary)
+		}
+	}
+
+	class func rawRepresentableDict<N: RawRepresentable>(field: [String: N], key: String, inout dictionary: [String : AnyObject]) {
+		let raw: [String: N.RawValue] = map(field) { (k, v) in (k, v.rawValue) }
+			.reduce([:]) { (var d, e) in
+				let (k, v) = e
+				d[k] = v
+				return d
+		}
+		basicType(raw, key: key, dictionary: &dictionary)
+	}
+
+	class func rawRepresentableDict<N: RawRepresentable>(field: [String: N]?, key: String, inout dictionary: [String : AnyObject]) {
+		if let field = field {
+			rawRepresentableDict(field, key: key, dictionary: &dictionary)
+		}
+	}
+
 	class func object<N: Mappable>(field: N, key: String, inout dictionary: [String : AnyObject]) {
 		setValue(Mapper().toJSON(field), forKey: key, dictionary: &dictionary)
 	}

--- a/ObjectMapper/Core/ToJSON.swift
+++ b/ObjectMapper/Core/ToJSON.swift
@@ -98,7 +98,17 @@ internal final class ToJSON {
             basicType(field, key: key, dictionary: &dictionary)
         }
     }
-    
+
+	class func rawRepresentable<N: RawRepresentable>(field: N, key: String, inout dictionary: [String : AnyObject]) {
+		basicType(field.rawValue, key: key, dictionary: &dictionary)
+	}
+
+  	class func rawRepresentable<N: RawRepresentable>(field: N?, key: String, inout dictionary: [String : AnyObject]) {
+			if let field = field {
+				rawRepresentable(field, key: key, dictionary: &dictionary)
+			}
+	  }
+
 	class func object<N: Mappable>(field: N, key: String, inout dictionary: [String : AnyObject]) {
 		setValue(Mapper().toJSON(field), forKey: key, dictionary: &dictionary)
 	}

--- a/ObjectMapperTests/BasicTypes.swift
+++ b/ObjectMapperTests/BasicTypes.swift
@@ -75,6 +75,30 @@ class BasicTypes: Mappable {
 	var enumIntOptional: EnumInt?
 	var enumIntImplicitlyUnwrapped: EnumInt!
 
+	enum EnumDouble: Double {
+		case Default
+		case Another
+	}
+	var enumDouble: EnumDouble = .Default
+	var enumDoubleOptional: EnumDouble?
+	var enumDoubleImplicitlyUnwrapped: EnumDouble!
+
+	enum EnumFloat: Float {
+		case Default
+		case Another
+	}
+	var enumFloat: EnumFloat = .Default
+	var enumFloatOptional: EnumFloat?
+	var enumFloatImplicitlyUnwrapped: EnumFloat!
+
+	enum EnumString: String {
+		case Default = "Default"
+		case Another = "Another"
+	}
+	var enumString: EnumString = .Default
+	var enumStringOptional: EnumString?
+	var enumStringImplicitlyUnwrapped: EnumString!
+
 	init() {}
 
 	required init?(_ map: Map) {
@@ -142,6 +166,15 @@ class BasicTypes: Mappable {
 		enumInt              <- map["enumInt"]
 		enumIntOptional          <- map["enumIntOpt"]
 		enumIntImplicitlyUnwrapped      <- map["enumIntImp"]
+		enumDouble              <- map["enumDouble"]
+		enumDoubleOptional          <- map["enumDoubleOpt"]
+		enumDoubleImplicitlyUnwrapped      <- map["enumDoubleImp"]
+		enumFloat              <- map["enumFloat"]
+		enumFloatOptional          <- map["enumFloatOpt"]
+		enumFloatImplicitlyUnwrapped      <- map["enumFloatImp"]
+		enumString              <- map["enumString"]
+		enumStringOptional          <- map["enumStringOpt"]
+		enumStringImplicitlyUnwrapped      <- map["enumStringImp"]
 	}
 }
 

--- a/ObjectMapperTests/BasicTypes.swift
+++ b/ObjectMapperTests/BasicTypes.swift
@@ -99,6 +99,13 @@ class BasicTypes: Mappable {
 	var enumStringOptional: EnumString?
 	var enumStringImplicitlyUnwrapped: EnumString!
 
+	var arrayEnumInt: [EnumInt] = []
+	var arrayEnumIntOptional: [EnumInt]?
+	var arrayEnumIntImplicitlyUnwrapped: [EnumInt]!
+	var dictEnumInt: [String: EnumInt] = [:]
+	var dictEnumIntOptional: [String: EnumInt]?
+	var dictEnumIntImplicitlyUnwrapped: [String: EnumInt]!
+
 	init() {}
 
 	required init?(_ map: Map) {
@@ -175,6 +182,13 @@ class BasicTypes: Mappable {
 		enumString              <- map["enumString"]
 		enumStringOptional          <- map["enumStringOpt"]
 		enumStringImplicitlyUnwrapped      <- map["enumStringImp"]
+
+		arrayEnumInt         <- map["arrayEnumInt"]
+		arrayEnumIntOptional     <- map["arrayEnumIntOpt"]
+		arrayEnumIntImplicitlyUnwrapped <- map["arrayEnumIntImp"]
+		dictEnumInt         <- map["dictEnumInt"]
+		dictEnumIntOptional     <- map["dictEnumIntOpt"]
+		dictEnumIntImplicitlyUnwrapped <- map["dictEnumIntImp"]
 	}
 }
 

--- a/ObjectMapperTests/BasicTypes.swift
+++ b/ObjectMapperTests/BasicTypes.swift
@@ -73,7 +73,7 @@ class BasicTypes: Mappable {
 	}
 	var enumInt: EnumInt = .Default
 	var enumIntOptional: EnumInt?
-	var enumIntImplicityUnwrapped: EnumInt!
+	var enumIntImplicitlyUnwrapped: EnumInt!
 
 	init() {}
 
@@ -141,7 +141,7 @@ class BasicTypes: Mappable {
 
 		enumInt              <- map["enumInt"]
 		enumIntOptional          <- map["enumIntOpt"]
-		enumIntImplicityUnwrapped      <- map["enumIntImp"]
+		enumIntImplicitlyUnwrapped      <- map["enumIntImp"]
 	}
 }
 

--- a/ObjectMapperTests/BasicTypes.swift
+++ b/ObjectMapperTests/BasicTypes.swift
@@ -67,6 +67,14 @@ class BasicTypes: Mappable {
 	var dictAnyObjectOptional: Dictionary<String, AnyObject>?
 	var dictAnyObjectImplicitlyUnwrapped: Dictionary<String, AnyObject>!
 
+	enum EnumInt: Int {
+		case Default
+		case Another
+	}
+	var enumInt: EnumInt = .Default
+	var enumIntOptional: EnumInt?
+	var enumIntImplicityUnwrapped: EnumInt!
+
 	init() {}
 
 	required init?(_ map: Map) {
@@ -130,6 +138,10 @@ class BasicTypes: Mappable {
 		dictAnyObject						<- map["dictAnyObject"]
 		dictAnyObjectOptional				<- map["dictAnyObjectOpt"]
 		dictAnyObjectImplicitlyUnwrapped	<- map["dictAnyObjectImp"]
+
+		enumInt              <- map["enumInt"]
+		enumIntOptional          <- map["enumIntOpt"]
+		enumIntImplicityUnwrapped      <- map["enumIntImp"]
 	}
 }
 

--- a/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -258,6 +258,18 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		expect(mappedObject?.dictAnyObjectOptional?[key] as? Int).to(equal(value2))
 		expect(mappedObject?.dictAnyObjectImplicitlyUnwrapped[key] as? Double).to(equal(value3))
 	}
+
+	func testMappingIntEnumFromJSON(){
+		var key = "key"
+		var value: BasicTypes.EnumInt = .Another
+		let JSONString = "{\"enumInt\" : \(value), \"enumIntOpt\" : \(value), \"enumIntImp\" : \(value) }"
+
+		var mappedObject = mapper.map(JSONString)
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.enumInt).to(equal(value))
+		expect(mappedObject?.enumIntOptional).to(equal(value))
+		expect(mappedObject?.enumIntImplicityUnwrapped).to(equal(value))
+	}
 	
 	func testObjectModelOptionalDictionnaryOfPrimitives() {
 		let JSON: [String: [String: AnyObject]] = ["dictStringString":["string": "string"], "dictStringBool":["string": false], "dictStringInt":["string": 1], "dictStringDouble":["string": 1.1], "dictStringFloat":["string": 1.2]]

--- a/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -270,7 +270,43 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		expect(mappedObject?.enumIntOptional).to(equal(value))
 		expect(mappedObject?.enumIntImplicitlyUnwrapped).to(equal(value))
 	}
-	
+
+	func testMappingDoubleEnumFromJSON(){
+		var key = "key"
+		var value: BasicTypes.EnumDouble = .Another
+		let JSONString = "{\"enumDouble\" : \(value.rawValue), \"enumDoubleOpt\" : \(value.rawValue), \"enumDoubleImp\" : \(value.rawValue) }"
+
+		var mappedObject = mapper.map(JSONString)
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.enumDouble).to(equal(value))
+		expect(mappedObject?.enumDoubleOptional).to(equal(value))
+		expect(mappedObject?.enumDoubleImplicitlyUnwrapped).to(equal(value))
+	}
+
+	func testMappingFloatEnumFromJSON(){
+		var key = "key"
+		var value: BasicTypes.EnumFloat = .Another
+		let JSONString = "{\"enumFloat\" : \(value.rawValue), \"enumFloatOpt\" : \(value.rawValue), \"enumFloatImp\" : \(value.rawValue) }"
+
+		var mappedObject = mapper.map(JSONString)
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.enumFloat).to(equal(value))
+		expect(mappedObject?.enumFloatOptional).to(equal(value))
+		expect(mappedObject?.enumFloatImplicitlyUnwrapped).to(equal(value))
+	}
+
+	func testMappingStringEnumFromJSON(){
+		var key = "key"
+		var value: BasicTypes.EnumString = .Another
+		let JSONString = "{\"enumString\" : \"\(value.rawValue)\", \"enumStringOpt\" : \"\(value.rawValue)\", \"enumStringImp\" : \"\(value.rawValue)\" }"
+
+		var mappedObject = mapper.map(JSONString)
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.enumString).to(equal(value))
+		expect(mappedObject?.enumStringOptional).to(equal(value))
+		expect(mappedObject?.enumStringImplicitlyUnwrapped).to(equal(value))
+	}
+
 	func testObjectModelOptionalDictionnaryOfPrimitives() {
 		let JSON: [String: [String: AnyObject]] = ["dictStringString":["string": "string"], "dictStringBool":["string": false], "dictStringInt":["string": 1], "dictStringDouble":["string": 1.1], "dictStringFloat":["string": 1.2]]
 		

--- a/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -262,7 +262,7 @@ class BasicTypesTestsFromJSON: XCTestCase {
 	func testMappingIntEnumFromJSON(){
 		var key = "key"
 		var value: BasicTypes.EnumInt = .Another
-		let JSONString = "{\"enumInt\" : \(value), \"enumIntOpt\" : \(value), \"enumIntImp\" : \(value) }"
+		let JSONString = "{\"enumInt\" : \(value.rawValue), \"enumIntOpt\" : \(value.rawValue), \"enumIntImp\" : \(value.rawValue) }"
 
 		var mappedObject = mapper.map(JSONString)
 		expect(mappedObject).notTo(beNil())

--- a/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -303,6 +303,29 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		expect(mappedObject?.enumStringImplicitlyUnwrapped).to(equal(value))
 	}
 
+	func testMappingEnumIntArrayFromJSON(){
+		var value: BasicTypes.EnumInt = .Another
+		let JSONString = "{ \"arrayEnumInt\" : [\(value.rawValue)], \"arrayEnumIntOpt\" : [\(value.rawValue)], \"arrayEnumIntImp\" : [\(value.rawValue)] }"
+
+		var mappedObject = mapper.map(JSONString)
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.arrayEnumInt.first).to(equal(value))
+		expect(mappedObject?.arrayEnumIntOptional?.first).to(equal(value))
+		expect(mappedObject?.arrayEnumIntImplicitlyUnwrapped?.first).to(equal(value))
+	}
+
+	func testMappingEnumIntDictionaryFromJSON(){
+		let key = "key"
+		let value: BasicTypes.EnumInt = .Another
+		let JSONString = "{ \"dictEnumInt\" : { \"\(key)\" : \(value.rawValue) }, \"dictEnumIntOpt\" : { \"\(key)\" : \(value.rawValue) }, \"dictEnumIntImp\" : { \"\(key)\" : \(value.rawValue) } }"
+
+		var mappedObject = mapper.map(JSONString)
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.dictEnumInt[key]).to(equal(value))
+		expect(mappedObject?.dictEnumIntOptional?[key]).to(equal(value))
+		expect(mappedObject?.dictEnumIntImplicitlyUnwrapped?[key]).to(equal(value))
+	}
+
 	func testObjectModelOptionalDictionnaryOfPrimitives() {
 		let JSON: [String: [String: AnyObject]] = ["dictStringString":["string": "string"], "dictStringBool":["string": false], "dictStringInt":["string": 1], "dictStringDouble":["string": 1.1], "dictStringFloat":["string": 1.2]]
 		

--- a/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -268,7 +268,7 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		expect(mappedObject).notTo(beNil())
 		expect(mappedObject?.enumInt).to(equal(value))
 		expect(mappedObject?.enumIntOptional).to(equal(value))
-		expect(mappedObject?.enumIntImplicityUnwrapped).to(equal(value))
+		expect(mappedObject?.enumIntImplicitlyUnwrapped).to(equal(value))
 	}
 	
 	func testObjectModelOptionalDictionnaryOfPrimitives() {

--- a/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -260,7 +260,6 @@ class BasicTypesTestsFromJSON: XCTestCase {
 	}
 
 	func testMappingIntEnumFromJSON(){
-		var key = "key"
 		var value: BasicTypes.EnumInt = .Another
 		let JSONString = "{\"enumInt\" : \(value.rawValue), \"enumIntOpt\" : \(value.rawValue), \"enumIntImp\" : \(value.rawValue) }"
 
@@ -272,7 +271,6 @@ class BasicTypesTestsFromJSON: XCTestCase {
 	}
 
 	func testMappingDoubleEnumFromJSON(){
-		var key = "key"
 		var value: BasicTypes.EnumDouble = .Another
 		let JSONString = "{\"enumDouble\" : \(value.rawValue), \"enumDoubleOpt\" : \(value.rawValue), \"enumDoubleImp\" : \(value.rawValue) }"
 
@@ -284,7 +282,6 @@ class BasicTypesTestsFromJSON: XCTestCase {
 	}
 
 	func testMappingFloatEnumFromJSON(){
-		var key = "key"
 		var value: BasicTypes.EnumFloat = .Another
 		let JSONString = "{\"enumFloat\" : \(value.rawValue), \"enumFloatOpt\" : \(value.rawValue), \"enumFloatImp\" : \(value.rawValue) }"
 
@@ -296,7 +293,6 @@ class BasicTypesTestsFromJSON: XCTestCase {
 	}
 
 	func testMappingStringEnumFromJSON(){
-		var key = "key"
 		var value: BasicTypes.EnumString = .Another
 		let JSONString = "{\"enumString\" : \"\(value.rawValue)\", \"enumStringOpt\" : \"\(value.rawValue)\", \"enumStringImp\" : \"\(value.rawValue)\" }"
 

--- a/ObjectMapperTests/BasicTypesTestsToJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsToJSON.swift
@@ -330,7 +330,7 @@ class BasicTypesTestsToJSON: XCTestCase {
 		var object = BasicTypes()
 		object.enumInt = value
 		object.enumIntOptional = value
-		object.enumIntImplicityUnwrapped = value
+		object.enumIntImplicitlyUnwrapped = value
 
 		let JSONString = Mapper().toJSONString(object, prettyPrint: true)
 		var mappedObject = mapper.map(JSONString!)
@@ -338,7 +338,7 @@ class BasicTypesTestsToJSON: XCTestCase {
 		expect(mappedObject).notTo(beNil())
 		expect(mappedObject?.enumInt).to(equal(value))
 		expect(mappedObject?.enumIntOptional).to(equal(value))
-		expect(mappedObject?.enumIntImplicityUnwrapped).to(equal(value))
+		expect(mappedObject?.enumIntImplicitlyUnwrapped).to(equal(value))
 	}
 
 	func testObjectToModelDictionnaryOfPrimitives() {

--- a/ObjectMapperTests/BasicTypesTestsToJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsToJSON.swift
@@ -389,6 +389,39 @@ class BasicTypesTestsToJSON: XCTestCase {
 		expect(mappedObject?.enumStringImplicitlyUnwrapped).to(equal(value))
 	}
 
+	func testMappingEnumIntArrayToJSON(){
+		let value = BasicTypes.EnumInt.Another
+		var object = BasicTypes()
+		object.arrayEnumInt = [value]
+		object.arrayEnumIntOptional = [value]
+		object.arrayEnumIntImplicitlyUnwrapped = [value]
+
+		let JSONString = Mapper().toJSONString(object, prettyPrint: true)
+		var mappedObject = mapper.map(JSONString!)
+
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.arrayEnumInt.first).to(equal(value))
+		expect(mappedObject?.arrayEnumIntOptional?.first).to(equal(value))
+		expect(mappedObject?.arrayEnumIntImplicitlyUnwrapped?.first).to(equal(value))
+	}
+
+	func testMappingEnumIntDictionaryToJSON(){
+		let key = "key"
+		let value = BasicTypes.EnumInt.Another
+		var object = BasicTypes()
+		object.dictEnumInt = [key: value]
+		object.dictEnumIntOptional = [key: value]
+		object.dictEnumIntImplicitlyUnwrapped = [key: value]
+
+		let JSONString = Mapper().toJSONString(object, prettyPrint: true)
+		var mappedObject = mapper.map(JSONString!)
+
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.dictEnumInt[key]).to(equal(value))
+		expect(mappedObject?.dictEnumIntOptional?[key]).to(equal(value))
+		expect(mappedObject?.dictEnumIntImplicitlyUnwrapped?[key]).to(equal(value))
+	}
+
 	func testObjectToModelDictionnaryOfPrimitives() {
 		var object = TestCollectionOfPrimitives()
 		object.dictStringString = ["string": "string"]

--- a/ObjectMapperTests/BasicTypesTestsToJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsToJSON.swift
@@ -325,6 +325,22 @@ class BasicTypesTestsToJSON: XCTestCase {
 		expect(mappedObject?.dictAnyObjectImplicitlyUnwrapped[key] as? String).to(equal(value))
 	}
 
+	func testMappingIntEnumToJSON(){
+		var value = BasicTypes.EnumInt.Another
+		var object = BasicTypes()
+		object.enumInt = value
+		object.enumIntOptional = value
+		object.enumIntImplicityUnwrapped = value
+
+		let JSONString = Mapper().toJSONString(object, prettyPrint: true)
+		var mappedObject = mapper.map(JSONString!)
+
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.enumInt).to(equal(value))
+		expect(mappedObject?.enumIntOptional).to(equal(value))
+		expect(mappedObject?.enumIntImplicityUnwrapped).to(equal(value))
+	}
+
 	func testObjectToModelDictionnaryOfPrimitives() {
 		var object = TestCollectionOfPrimitives()
 		object.dictStringString = ["string": "string"]

--- a/ObjectMapperTests/BasicTypesTestsToJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsToJSON.swift
@@ -341,6 +341,54 @@ class BasicTypesTestsToJSON: XCTestCase {
 		expect(mappedObject?.enumIntImplicitlyUnwrapped).to(equal(value))
 	}
 
+	func testMappingDoubleEnumToJSON(){
+		var value = BasicTypes.EnumDouble.Another
+		var object = BasicTypes()
+		object.enumDouble = value
+		object.enumDoubleOptional = value
+		object.enumDoubleImplicitlyUnwrapped = value
+
+		let JSONString = Mapper().toJSONString(object, prettyPrint: true)
+		var mappedObject = mapper.map(JSONString!)
+
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.enumDouble).to(equal(value))
+		expect(mappedObject?.enumDoubleOptional).to(equal(value))
+		expect(mappedObject?.enumDoubleImplicitlyUnwrapped).to(equal(value))
+	}
+
+	func testMappingFloatEnumToJSON(){
+		var value = BasicTypes.EnumFloat.Another
+		var object = BasicTypes()
+		object.enumFloat = value
+		object.enumFloatOptional = value
+		object.enumFloatImplicitlyUnwrapped = value
+
+		let JSONString = Mapper().toJSONString(object, prettyPrint: true)
+		var mappedObject = mapper.map(JSONString!)
+
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.enumFloat).to(equal(value))
+		expect(mappedObject?.enumFloatOptional).to(equal(value))
+		expect(mappedObject?.enumFloatImplicitlyUnwrapped).to(equal(value))
+	}
+
+	func testMappingStringEnumToJSON(){
+		var value = BasicTypes.EnumString.Another
+		var object = BasicTypes()
+		object.enumString = value
+		object.enumStringOptional = value
+		object.enumStringImplicitlyUnwrapped = value
+
+		let JSONString = Mapper().toJSONString(object, prettyPrint: true)
+		var mappedObject = mapper.map(JSONString!)
+
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.enumString).to(equal(value))
+		expect(mappedObject?.enumStringOptional).to(equal(value))
+		expect(mappedObject?.enumStringImplicitlyUnwrapped).to(equal(value))
+	}
+
 	func testObjectToModelDictionnaryOfPrimitives() {
 		var object = TestCollectionOfPrimitives()
 		object.dictStringString = ["string": "string"]

--- a/ObjectMapperTests/NestedKeysTests.swift
+++ b/ObjectMapperTests/NestedKeysTests.swift
@@ -48,6 +48,12 @@ class NestedKeysTests: XCTestCase {
 					"floatDict": ["5": 123.456 as Float],
 					"stringDict": ["6": "InDict"],
 
+					"int64Enum": 1000,
+					"intEnum": 255,
+					"doubleEnum": 100.0,
+					"floatEnum": 100.0,
+					"stringEnum": "String B",
+
 					"nested": [
 						"object": ["value": 987],
 						"objectArray": [ ["value": 123], ["value": 456] ],
@@ -87,6 +93,12 @@ class NestedKeysTests: XCTestCase {
 		expect(value.floatDict).to(equal(valueFromParsedJSON.floatDict))
 		expect(value.stringDict).to(equal(valueFromParsedJSON.stringDict))
 
+		expect(value.int64Enum).to(equal(valueFromParsedJSON.int64Enum))
+		expect(value.intEnum).to(equal(valueFromParsedJSON.intEnum))
+		expect(value.doubleEnum).to(equal(valueFromParsedJSON.doubleEnum))
+		expect(value.floatEnum).to(equal(valueFromParsedJSON.floatEnum))
+		expect(value.stringEnum).to(equal(valueFromParsedJSON.stringEnum))
+
 		expect(value.object).to(equal(valueFromParsedJSON.object))
 		expect(value.objectArray).to(equal(valueFromParsedJSON.objectArray))
 		expect(value.objectDict).to(equal(valueFromParsedJSON.objectDict))
@@ -115,6 +127,12 @@ class NestedKeys: Mappable {
 	var doubleDict: [String: Double] = [:]
 	var floatDict: [String: Float] = [:]
 	var stringDict: [String: String] = [:]
+
+	var int64Enum: Int64Enum?
+	var intEnum: IntEnum?
+	var doubleEnum: DoubleEnum?
+	var floatEnum: FloatEnum?
+	var stringEnum: StringEnum?
 
 	var object: Object?
 	var objectArray: [Object] = []
@@ -146,6 +164,12 @@ class NestedKeys: Mappable {
 		floatDict	<- map["nested.nested.floatDict"]
 		stringDict	<- map["nested.nested.stringDict"]
 
+		int64Enum	<- map["nested.nested.int64Enum"]
+		intEnum		<- map["nested.nested.intEnum"]
+		doubleEnum	<- map["nested.nested.doubleEnum"]
+		floatEnum	<- map["nested.nested.floatEnum"]
+		stringEnum	<- map["nested.nested.stringEnum"]
+
 		object		<- map["nested.nested.nested.object"]
 		objectArray	<- map["nested.nested.nested.objectArray"]
 		objectDict	<- map["nested.nested.nested.objectDict"]
@@ -166,4 +190,29 @@ class Object: Mappable, Equatable {
 
 func == (lhs: Object, rhs: Object) -> Bool {
 	return lhs.value == rhs.value
+}
+
+enum Int64Enum: NSNumber {
+	case A = 0
+	case B = 1000
+}
+
+enum IntEnum: Int {
+	case A = 0
+	case B = 255
+}
+
+enum DoubleEnum: Double {
+	case A = 0.0
+	case B = 100.0
+}
+
+enum FloatEnum: Float {
+	case A = 0.0
+	case B = 100.0
+}
+
+enum StringEnum: String {
+	case A = "String A"
+	case B = "String B"
 }

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -274,7 +274,21 @@ class ObjectMapperTests: XCTestCase {
 		expect(tasks?[0].percentage).to(equal(percentage1))
 		expect(tasks?[1].percentage).to(equal(percentage2))
 	}
-	
+
+	func testArrayOfEnumObjects(){
+    let a: ExampleEnum = .A
+    let b: ExampleEnum = .B
+    let c: ExampleEnum = .C
+
+    let JSONString = "{ \"enums\": [\(a.rawValue), \(b.rawValue), \(c.rawValue)] }"
+
+		let enumArray = Mapper<ExampleEnumArray>().map(JSONString)
+		let enums = enumArray?.enums
+		expect(enums).notTo(beNil())
+		expect(enums?.count).to(equal(3))
+
+	}
+
 	func testDictionaryOfCustomObjects(){
 		let percentage1: Double = 0.1
 		let percentage2: Double = 1792.41
@@ -648,5 +662,23 @@ class ConcreteItem: Mappable {
 class SubclassWithGenericArrayInSuperclass<Unused>: WithGenericArray<ConcreteItem> {
 	required init?(_ map: Map) {
 		super.init(map)
+	}
+}
+
+enum ExampleEnum: Int {
+	case A
+	case B
+	case C
+}
+
+class ExampleEnumArray: Mappable {
+	var enums: [ExampleEnum] = []
+
+	required init? (_ map: Map) {
+		mapping(map)
+	}
+
+	func mapping(map: Map) {
+		enums <- map["enums"]
 	}
 }

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -90,6 +90,7 @@ class ObjectMapperTests: XCTestCase {
         let float: Float = 123.231
         let drinker = true
         let smoker = false
+			  let sex: Sex = .Female
         let arr = [ "bla", true, 42 ]
         let directory = [
             "key1" : "value1",
@@ -99,7 +100,7 @@ class ObjectMapperTests: XCTestCase {
         
         let subUserJSON = "{\"identifier\" : \"user8723\", \"drinker\" : true, \"age\": 17, \"username\" : \"sub user\" }"
         
-        let userJSONString = "{\"username\":\"\(username)\",\"identifier\":\"\(identifier)\",\"photoCount\":\(photoCount),\"age\":\(age),\"drinker\":\(drinker),\"smoker\":\(smoker), \"arr\":[ \"bla\", true, 42 ], \"dict\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"arrOpt\":[ \"bla\", true, 42 ], \"dictOpt\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 },\"weight\": \(weight), \"float\": \(float), \"friend\": \(subUserJSON), \"friendDictionary\":{ \"bestFriend\": \(subUserJSON)}}"
+        let userJSONString = "{\"username\":\"\(username)\",\"identifier\":\"\(identifier)\",\"photoCount\":\(photoCount),\"age\":\(age),\"drinker\":\(drinker),\"smoker\":\(smoker), \"sex\":\"\(sex.rawValue)\", \"arr\":[ \"bla\", true, 42 ], \"dict\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"arrOpt\":[ \"bla\", true, 42 ], \"dictOpt\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 },\"weight\": \(weight), \"float\": \(float), \"friend\": \(subUserJSON), \"friendDictionary\":{ \"bestFriend\": \(subUserJSON)}}"
         
         let user = Mapper().map(userJSONString, toObject: User())
 
@@ -111,6 +112,7 @@ class ObjectMapperTests: XCTestCase {
 		expect(float).to(equal(user.float))
 		expect(drinker).to(equal(user.drinker))
 		expect(smoker).to(equal(user.smoker))
+		expect(sex).to(equal(user.sex))
         //println(Mapper().toJSONString(user, prettyPrint: true))
     }
     

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -53,6 +53,7 @@ class ObjectMapperTests: XCTestCase {
         let float: Float = 123.231
         let drinker = true
         let smoker = false
+  			let sex: Sex = .Female
         let arr = [ "bla", true, 42 ]
         let directory = [
             "key1" : "value1",
@@ -62,7 +63,7 @@ class ObjectMapperTests: XCTestCase {
         
         let subUserJSON = "{\"identifier\" : \"user8723\", \"drinker\" : true, \"age\": 17, \"username\" : \"sub user\" }"
         
-        let userJSONString = "{\"username\":\"\(username)\",\"identifier\":\"\(identifier)\",\"photoCount\":\(photoCount),\"age\":\(age),\"drinker\":\(drinker),\"smoker\":\(smoker), \"arr\":[ \"bla\", true, 42 ], \"dict\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"arrOpt\":[ \"bla\", true, 42 ], \"dictOpt\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"weight\": \(weight), \"float\": \(float), \"friend\": \(subUserJSON), \"friendDictionary\":{ \"bestFriend\": \(subUserJSON)}}"
+        let userJSONString = "{\"username\":\"\(username)\",\"identifier\":\"\(identifier)\",\"photoCount\":\(photoCount),\"age\":\(age),\"drinker\":\(drinker),\"smoker\":\(smoker), \"sex\":\"\(sex.rawValue)\", \"arr\":[ \"bla\", true, 42 ], \"dict\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"arrOpt\":[ \"bla\", true, 42 ], \"dictOpt\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"weight\": \(weight), \"float\": \(float), \"friend\": \(subUserJSON), \"friendDictionary\":{ \"bestFriend\": \(subUserJSON)}}"
 
 		let user = userMapper.map(userJSONString)!
 		
@@ -75,6 +76,7 @@ class ObjectMapperTests: XCTestCase {
 		expect(float).to(equal(user.float))
 		expect(drinker).to(equal(user.drinker))
 		expect(smoker).to(equal(user.smoker))
+		expect(sex).to(equal(user.sex))
 
 		//println(Mapper().toJSONString(user, prettyPrint: true))
     }
@@ -509,6 +511,11 @@ struct Student: Mappable {
 	}
 }
 
+enum Sex: String {
+	case Male = "Male"
+	case Female = "Female"
+}
+
 class User: Mappable {
     
     var username: String = ""
@@ -519,6 +526,7 @@ class User: Mappable {
     var float: Float?
     var drinker: Bool = false
     var smoker: Bool?
+  	var sex: Sex?
     var arr: [AnyObject] = []
     var arrOptional: [AnyObject]?
     var dict: [String : AnyObject] = [:]
@@ -543,6 +551,7 @@ class User: Mappable {
 		float            <- map["float"]
 		drinker          <- map["drinker"]
 		smoker           <- map["smoker"]
+		sex              <- map["sex"]
 		arr              <- map["arr"]
 		arrOptional      <- map["arrOpt"]
 		dict             <- map["dict"]

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -286,7 +286,9 @@ class ObjectMapperTests: XCTestCase {
 		let enums = enumArray?.enums
 		expect(enums).notTo(beNil())
 		expect(enums?.count).to(equal(3))
-
+		expect(enums?[0]).to(equal(a))
+		expect(enums?[1]).to(equal(b))
+		expect(enums?[2]).to(equal(c))
 	}
 
 	func testDictionaryOfCustomObjects(){
@@ -301,7 +303,20 @@ class ObjectMapperTests: XCTestCase {
 		expect(task).notTo(beNil())
 		expect(task?.percentage).to(equal(percentage1))
 	}
-	
+
+	func testDictionryOfEnumObjects(){
+		let a: ExampleEnum = .A
+		let b: ExampleEnum = .B
+		let c: ExampleEnum = .C
+
+		let JSONString = "{ \"enums\": {\"A\": \(a.rawValue), \"B\": \(b.rawValue), \"C\": \(c.rawValue)} }"
+
+		let enumDict = Mapper<ExampleEnumDictionary>().map(JSONString)
+		let enums = enumDict?.enums
+		expect(enums).notTo(beNil())
+		expect(enums?.count).to(equal(3))
+	}
+
 	func testDoubleParsing(){
 		let percentage1: Double = 1792.41
 		
@@ -673,6 +688,18 @@ enum ExampleEnum: Int {
 
 class ExampleEnumArray: Mappable {
 	var enums: [ExampleEnum] = []
+
+	required init? (_ map: Map) {
+		mapping(map)
+	}
+
+	func mapping(map: Map) {
+		enums <- map["enums"]
+	}
+}
+
+class ExampleEnumDictionary: Mappable {
+	var enums: [String: ExampleEnum] = [:]
 
 	required init? (_ map: Map) {
 		mapping(map)

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -200,6 +200,7 @@ class ObjectMapperTests: XCTestCase {
         user.weight = 150
         user.drinker = true
         user.smoker = false
+			  user.sex = .Female
         user.arr = ["cheese", 11234]
         
         let JSONString = Mapper().toJSONString(user, prettyPrint: true)
@@ -213,6 +214,7 @@ class ObjectMapperTests: XCTestCase {
 		expect(user.weight).to(equal(parsedUser.weight))
 		expect(user.drinker).to(equal(parsedUser.drinker))
 		expect(user.smoker).to(equal(parsedUser.smoker))
+		expect(user.sex).to(equal(parsedUser.sex))
     }
 
     func testUnknownPropertiesIgnored() {


### PR DESCRIPTION
This pull request add a function that Enum (RawRespresentable) objects becomes mappable. I know another way that use Custom Transforms. However, this is more simple to use.
This pull request is still work in progress. Several more tests are necessary. If you like this pull request, I will add more tests.
