### PR TITLE
Added support for NSString input

### DIFF
--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -163,11 +163,13 @@ public final class Mapper<N: Mappable> {
 	}
 
 	/**
-	* Maps a JSON object to a Mappable object if it is a JSON dictionary, or returns nil.
+	* Maps a JSON object to a Mappable object if it is a JSON dictionary or NSString, or returns nil.
 	*/
 	public func map(JSON: AnyObject?) -> N? {
 		if let JSON = JSON as? [String : AnyObject] {
 			return map(JSON)
+		}else if let JSONString = JSON as? String {
+			return map(JSONString)
 		}
 
 		return nil

--- a/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -100,7 +100,19 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		expect(mappedObject?.anyObjectOptional as? Int).to(equal(value2))
 		expect(mappedObject?.anyObjectImplicitlyUnwrapped as? Double).to(equal(value3))
 	}
-	
+
+	func testMappingStringFromNSStringJSON(){
+		var value: String = "STRINGNGNGG"
+		let JSONNSString : NSString = "{\"string\" : \"\(value)\", \"stringOpt\" : \"\(value)\", \"stringImp\" : \"\(value)\"}"
+		
+		var mappedObject = mapper.map(JSONNSString)
+		
+		expect(mappedObject).notTo(beNil())
+		expect(mappedObject?.string).to(equal(value))
+		expect(mappedObject?.stringOptional).to(equal(value))
+		expect(mappedObject?.stringImplicityUnwrapped).to(equal(value))
+	}
+
 	// MARK: Test mapping Arrays to JSON and back (with basic types in them Bool, Int, Double, Float, String)
 	
 	func testMappingBoolArrayFromJSON(){


### PR DESCRIPTION
NSString's are not automatically converted into Strings in swift 1.2. 
Therefore when you use the following code: 

    let myString = NSString(data: myData, encoding: NSUTF8StringEncoding)
    let myObject = Mapper<MyOject>().map(myString)

This method will be called and will return nil:

	/**
	* Maps a JSON object to a Mappable object if it is a JSON dictionary or NSString, or returns nil.
	*/
	public func map(JSON: AnyObject?) -> N? {
		if let JSON = JSON as? [String : AnyObject] {
			return map(JSON)
		}

		return nil
	}

While you would like to call: 

	/**
	* Map a JSON string to an object that conforms to Mappable
	*/
	public func map(JSONString: String) -> N? {
		if let JSON = parseJSONDictionary(JSONString) {
			return map(JSON)
		}
		return nil
	}

This took me 2 hours to figure out. 

It would be cool if a warning / compile error would be thrown to avoid a bug hunt like mine.
Another solution would be to support NSString, I've created a PR for this.