### PR TITLE
Swift 2.0

### DIFF
--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -73,7 +73,7 @@ private func valueFor(keyPathComponents: ArraySlice<String>, dictionary: [String
 			return nil
 
 		case let dict as [String : AnyObject] where keyPathComponents.count > 1:
-			let tail = dropFirst(keyPathComponents)
+			let tail = keyPathComponents.dropFirst()
 			return valueFor(tail, dictionary: dict)
 
 		default:

--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol Mappable {
-	static func newInstance() -> Mappable
+    init?(_ map: Map)
 	mutating func mapping(map: Map)
 }
 
@@ -143,11 +143,12 @@ public final class Mapper<N: Mappable> {
 
 	/// Maps a JSON dictionary to an object that conforms to Mappable
 	public func map(JSONDictionary: [String : AnyObject]) -> N? {
-		if var object = N.newInstance() as? N {
-			let map = Map(mappingType: .FromJSON, JSONDictionary: JSONDictionary)
-			object.mapping(map)
-			return object
-		}
+        let map = Map(mappingType: .FromJSON, JSONDictionary: JSONDictionary)
+        if let object = N(map) as? Mappable{
+            if let n=object as? N {
+                return n
+            }
+        }
 		return nil
 	}
 

--- a/ObjectMapper/Core/ToJSON.swift
+++ b/ObjectMapper/Core/ToJSON.swift
@@ -9,7 +9,7 @@
 import class Foundation.NSNumber
 
 private func setValue(value: AnyObject, forKey key: String, inout dictionary: [String : AnyObject]) {
-	let keyComponents = ArraySlice(split(key.characters) { $0 == "." })
+	let keyComponents = ArraySlice(key.characters.split() { $0 == "." })
 	return setValue(value, forKeyPathComponents: keyComponents, dictionary: &dictionary)
 }
 
@@ -28,7 +28,7 @@ private func setValue(value: AnyObject, forKeyPathComponents components: ArraySl
 			child = [:]
 		}
 
-		let tail = dropFirst(components)
+		let tail = components.dropFirst()
 		setValue(value, forKeyPathComponents: tail, dictionary: &child!)
 
 		return dictionary[String(head)] = child


### PR DESCRIPTION
In swift 2.0 with Xcode7 B6, static methods are **reputed finals!**
The "static func newInstance() -> Mappable" cannot be overridden anymore.

My proposition consists to pass the map to the initializer init?(_ map: Map). When a mappable object inheritates from another mappable object it should call super before proceeding to its own mapping. This approach is consistent with NSCoder pattern.

``` swift
// MARK: Mappable

required init?(_ map: Map) {
        super.init(map)
        mapping(map)
}
```
