### PR TITLE
Fixes memory leak when using switch against multiple types with as pattern

### DIFF
--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -99,15 +99,12 @@ private func valueFor(keyPathComponents: ArraySlice<String>, dictionary: [String
 	}
 
 	if let object: AnyObject = dictionary[keyPathComponents.first!] {
-		switch object {
-		case is NSNull:
+		if object is NSNull {
 			return nil
-
-		case let dict as [String : AnyObject] where keyPathComponents.count > 1:
+		}else if let dict = object as? [String : AnyObject] where keyPathComponents.count > 1 {
 			let tail = keyPathComponents.dropFirst()
 			return valueFor(tail, dictionary: dict)
-
-		default:
+		}else {
 			return object
 		}
 	}


### PR DESCRIPTION
Should close https://github.com/Hearst-DD/ObjectMapper/issues/200

Fixes memory leak when using switch against multiple types with as patterns that may cause a memory leak.

See https://developer.apple.com/library/prerelease/watchos/releasenotes/DeveloperTools/RN-Xcode/Chapters/xc7_release_notes.html under Swift for more info