### PR TITLE
Added support for nested arrays

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		37AFD9B91AAD191C00AB59B5 /* CustomDateFormatTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */; };
+		6100B1C01BD76A030011114A /* NestedArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6100B1BF1BD76A020011114A /* NestedArrayTests.swift */; settings = {ASSET_TAGS = (); }; };
 		6A2AD0451B2C786C0097E150 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC419F048FE00E7A677 /* Mapper.swift */; };
 		6A2AD0461B2C786C0097E150 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC519F048FE00E7A677 /* Operators.swift */; };
 		6A2AD0471B2C786C0097E150 /* FromJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC319F048FE00E7A677 /* FromJSON.swift */; };
@@ -116,6 +117,7 @@
 
 /* Begin PBXFileReference section */
 		37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomDateFormatTransform.swift; sourceTree = "<group>"; };
+		6100B1BF1BD76A020011114A /* NestedArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedArrayTests.swift; sourceTree = "<group>"; };
 		6A2AD03D1B2C78540097E150 /* ObjectMapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectMapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A3774331A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BasicTypesTestsToJSON.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6A51372B1AADDE2700B82516 /* DateFormatterTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateFormatterTransform.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 				6A3774331A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift */,
 				6A51372E1AADE12C00B82516 /* CustomTransformTests.swift */,
 				CD44374C1AAE9C1100A271BA /* NestedKeysTests.swift */,
+				6100B1BF1BD76A020011114A /* NestedArrayTests.swift */,
 				6AAC8F8519F03C2900E7A677 /* ObjectMapperTests.swift */,
 				6AAC8F8319F03C2900E7A677 /* Supporting Files */,
 			);
@@ -548,6 +551,7 @@
 				6A51372F1AADE12C00B82516 /* CustomTransformTests.swift in Sources */,
 				6A6AEB981A9387D0002573D3 /* BasicTypes.swift in Sources */,
 				6AAC8F8619F03C2900E7A677 /* ObjectMapperTests.swift in Sources */,
+				6100B1C01BD76A030011114A /* NestedArrayTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ObjectMapper/Core/Map.swift
+++ b/ObjectMapper/Core/Map.swift
@@ -42,7 +42,7 @@ public final class Map {
 			currentValue = JSONDictionary[key]
 		} else {
 			// break down the components of the key that are separated by .
-			currentValue = valueFor(ArraySlice(key.componentsSeparatedByString(".")), dictionary: JSONDictionary)
+			currentValue = valueFor(ArraySlice(key.componentsSeparatedByString(".")), collection: JSONDictionary)
 		}
 		
 		return self
@@ -81,19 +81,34 @@ public final class Map {
 }
 
 /// Fetch value from JSON dictionary, loop through them until we reach the desired object.
-private func valueFor(keyPathComponents: ArraySlice<String>, dictionary: [String : AnyObject]) -> AnyObject? {
+private func valueFor(keyPathComponents: ArraySlice<String>, collection: AnyObject?) -> AnyObject? {
 	// Implement it as a tail recursive function.
 	
 	if keyPathComponents.isEmpty {
 		return nil
 	}
 	
-	if let object: AnyObject = dictionary[keyPathComponents.first!] {
+	//optional object to keep optional retreived from collection
+	var optionalObject: AnyObject?
+	
+	//check if collection is dictionary or array (if it's array, also try to convert keypath to Int as index)
+	if let dictionary = collection as? [String : AnyObject] {
+		//keep retreved optional
+		optionalObject = dictionary[keyPathComponents.first!]
+	} else if let array = collection as? [AnyObject], index = Int(String(keyPathComponents.first!.characters.dropFirst())) {
+		//keep retreved optional
+		optionalObject = array[index]
+	}
+	
+	if let object: AnyObject = optionalObject {
 		if object is NSNull {
 			return nil
 		} else if let dict = object as? [String : AnyObject] where keyPathComponents.count > 1 {
 			let tail = keyPathComponents.dropFirst()
-			return valueFor(tail, dictionary: dict)
+			return valueFor(tail, collection: dict)
+		} else if let dict = object as? [AnyObject] where keyPathComponents.count > 1 {
+			let tail = keyPathComponents.dropFirst()
+			return valueFor(tail, collection: dict)
 		} else {
 			return object
 		}

--- a/ObjectMapper/Core/Map.swift
+++ b/ObjectMapper/Core/Map.swift
@@ -95,7 +95,7 @@ private func valueFor(keyPathComponents: ArraySlice<String>, collection: AnyObje
 	if let dictionary = collection as? [String : AnyObject] {
 		//keep retreved optional
 		optionalObject = dictionary[keyPathComponents.first!]
-	} else if let array = collection as? [AnyObject], index = Int(String(keyPathComponents.first!.characters.dropFirst())) {
+	} else if let array = collection as? [AnyObject], index = Int(String(keyPathComponents.first!)) {
 		//keep retreved optional
 		optionalObject = array[index]
 	}

--- a/ObjectMapperTests/NestedArrayTests.swift
+++ b/ObjectMapperTests/NestedArrayTests.swift
@@ -1,0 +1,60 @@
+//
+//  NestedArrayTests.swift
+//  ObjectMapper
+//
+//  Created by Ruben Samsonyan on 10/21/15.
+//  Copyright © 2015 hearst. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import ObjectMapper
+import Nimble
+
+class NestedArrayTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+	
+	func testNestedArray() {
+		let JSON: [String: AnyObject] = [ "nested": [ ["value": 123], ["value": 456] ] ]
+		
+		let mapper = Mapper<NestedArray>()
+		
+		let value: NestedArray! = mapper.map(JSON)
+		expect(value).notTo(beNil())
+		
+		let JSONFromValue = mapper.toJSON(value)
+		let valueFromParsedJSON: NestedArray! = mapper.map(JSONFromValue)
+		expect(valueFromParsedJSON).notTo(beNil())
+		
+		expect(value.value_0).to(equal(valueFromParsedJSON.value_0))
+		expect(value.value_1).to(equal(valueFromParsedJSON.value_1))
+		
+	}
+
+}
+
+class NestedArray: Mappable {
+	
+	var value_0: Int?
+	var value_1: Int?
+	
+	required init?(_ map: Map){
+		
+	}
+	
+	func mapping(map: Map) {
+		
+		value_0	<- map["nested.0.value"]
+		value_1	<- map["nested.1.value"]
+		
+	}
+}


### PR DESCRIPTION
For example if json dictionary containes nested array, and user needs first element of array, path could be written like this: ["names.0"]. I have done this, because for my current project I coudn't get this kind of thing, but I needed, because I'm using openweathermap.org, and it retreives nested array for weather, and I needed to get weather descrition from that array. In my case for now I'm using it like this ["weather.0.description"]