### PR TITLE
Mappable, Array<Mappable, and Set<Mappable> initializers and toJSON

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		37AFD9B91AAD191C00AB59B5 /* CustomDateFormatTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */; };
+		3BAD2C0C1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
+		3BAD2C0D1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
+		3BAD2C0E1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
+		3BAD2C101BDDC0B000E6B203 /* MappableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */; };
+		3BAD2C111BDDC0B000E6B203 /* MappableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */; };
 		6A2AD0451B2C786C0097E150 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC419F048FE00E7A677 /* Mapper.swift */; };
 		6A2AD0461B2C786C0097E150 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC519F048FE00E7A677 /* Operators.swift */; };
 		6A2AD0471B2C786C0097E150 /* FromJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC319F048FE00E7A677 /* FromJSON.swift */; };
@@ -36,9 +41,9 @@
 		6AAE6A431ACED93500FBC899 /* ObjectMapper.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CD1602FF1AC023D5000CD69A /* ObjectMapper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6AAE6A441ACED93B00FBC899 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CD208C981AC10D2B00E21781 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6AC458191BA350CF00054758 /* ObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AAC8F7B19F03C2900E7A677 /* ObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6ACB15D21BC7F1D0006C029C /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACB15D11BC7F1D0006C029C /* Map.swift */; settings = {ASSET_TAGS = (); }; };
-		6ACB15D31BC7F1D0006C029C /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACB15D11BC7F1D0006C029C /* Map.swift */; settings = {ASSET_TAGS = (); }; };
-		6ACB15D41BC7F1D0006C029C /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACB15D11BC7F1D0006C029C /* Map.swift */; settings = {ASSET_TAGS = (); }; };
+		6ACB15D21BC7F1D0006C029C /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACB15D11BC7F1D0006C029C /* Map.swift */; };
+		6ACB15D31BC7F1D0006C029C /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACB15D11BC7F1D0006C029C /* Map.swift */; };
+		6ACB15D41BC7F1D0006C029C /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACB15D11BC7F1D0006C029C /* Map.swift */; };
 		BC1E7F371ABC44C000F9B1CF /* EnumTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1E7F361ABC44C000F9B1CF /* EnumTransform.swift */; };
 		CD16030A1AC023D6000CD69A /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD1602FF1AC023D5000CD69A /* ObjectMapper.framework */; };
 		CD1603181AC02437000CD69A /* ObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AAC8F7B19F03C2900E7A677 /* ObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -116,6 +121,8 @@
 
 /* Begin PBXFileReference section */
 		37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomDateFormatTransform.swift; sourceTree = "<group>"; };
+		3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mappable.swift; sourceTree = "<group>"; };
+		3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MappableExtensionsTests.swift; sourceTree = "<group>"; };
 		6A2AD03D1B2C78540097E150 /* ObjectMapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectMapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A3774331A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BasicTypesTestsToJSON.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6A51372B1AADDE2700B82516 /* DateFormatterTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateFormatterTransform.swift; sourceTree = "<group>"; };
@@ -251,6 +258,7 @@
 				6A51372E1AADE12C00B82516 /* CustomTransformTests.swift */,
 				CD44374C1AAE9C1100A271BA /* NestedKeysTests.swift */,
 				6AAC8F8519F03C2900E7A677 /* ObjectMapperTests.swift */,
+				3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */,
 				6AAC8F8319F03C2900E7A677 /* Supporting Files */,
 			);
 			path = ObjectMapperTests;
@@ -273,6 +281,7 @@
 				6AAC8FC519F048FE00E7A677 /* Operators.swift */,
 				6AAC8FC319F048FE00E7A677 /* FromJSON.swift */,
 				6AAC8FC719F048FE00E7A677 /* ToJSON.swift */,
+				3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -503,6 +512,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A2AD0451B2C786C0097E150 /* Mapper.swift in Sources */,
+				3BAD2C0E1BDDB10D00E6B203 /* Mappable.swift in Sources */,
 				6A2AD0461B2C786C0097E150 /* Operators.swift in Sources */,
 				6ACB15D41BC7F1D0006C029C /* Map.swift in Sources */,
 				6A2AD0471B2C786C0097E150 /* FromJSON.swift in Sources */,
@@ -523,6 +533,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				37AFD9B91AAD191C00AB59B5 /* CustomDateFormatTransform.swift in Sources */,
+				3BAD2C0C1BDDB10D00E6B203 /* Mappable.swift in Sources */,
 				CD50B6FD1A82518300744312 /* TransformType.swift in Sources */,
 				6ACB15D21BC7F1D0006C029C /* Map.swift in Sources */,
 				6AAC8FD319F048FE00E7A677 /* DateTransform.swift in Sources */,
@@ -542,6 +553,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BAD2C101BDDC0B000E6B203 /* MappableExtensionsTests.swift in Sources */,
 				6A6AEB961A93874F002573D3 /* BasicTypesTestsFromJSON.swift in Sources */,
 				CD44374D1AAE9C1100A271BA /* NestedKeysTests.swift in Sources */,
 				6A3774341A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift in Sources */,
@@ -556,6 +568,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CD1603221AC02472000CD69A /* TransformType.swift in Sources */,
+				3BAD2C0D1BDDB10D00E6B203 /* Mappable.swift in Sources */,
 				CD1603201AC02461000CD69A /* CustomDateFormatTransform.swift in Sources */,
 				CD16031E1AC02461000CD69A /* DateFormatterTransform.swift in Sources */,
 				6ACB15D31BC7F1D0006C029C /* Map.swift in Sources */,
@@ -575,6 +588,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BAD2C111BDDC0B000E6B203 /* MappableExtensionsTests.swift in Sources */,
 				CD1603261AC02480000CD69A /* BasicTypesTestsFromJSON.swift in Sources */,
 				CD1603291AC02480000CD69A /* NestedKeysTests.swift in Sources */,
 				CD1603251AC02480000CD69A /* BasicTypes.swift in Sources */,

--- a/ObjectMapper/Core/Mappable.swift
+++ b/ObjectMapper/Core/Mappable.swift
@@ -1,0 +1,101 @@
+//
+//  Mappable.swift
+//  ObjectMapper
+//
+//  Created by Scott Hoyt on 10/25/15.
+//  Copyright © 2015 hearst. All rights reserved.
+//
+
+import Foundation
+
+public protocol Mappable {
+	init?(_ map: Map)
+	mutating func mapping(map: Map)
+}
+
+public extension Mappable {
+	
+	/// Initializes object from a JSON String
+	public init?(JSONString: String?) {
+		if let obj: Self = Mapper().map(JSONString) {
+			self = obj
+		}
+		else {
+			return nil
+		}
+	}
+	
+	/// Initializes object from a JSON Dictionary
+	public init?(JSON: [String : AnyObject]?) {
+		if let obj: Self = Mapper().map(JSON) {
+			self = obj
+		}
+		else {
+			return nil
+		}
+	}
+	
+	/// Returns the JSON Dictionary for the object
+	public func toJSON() -> [String: AnyObject]? {
+		return Mapper().toJSON(self)
+	}
+	
+}
+
+public extension Array where Element : Mappable {
+	
+	/// Initialize Array from a JSON String
+	public init?(JSONString: String?) {
+		if let obj: [Element] = Mapper().mapArray(JSONString) {
+			self = obj
+		}
+		else {
+			return nil
+		}
+	}
+	
+	/// Initialize Array from a JSON Array
+	public init?(JSONArray: [[String : AnyObject]]?) {
+		if let obj: [Element] = Mapper().mapArray(JSONArray) {
+			self = obj
+		}
+		else {
+			return nil
+		}
+	}
+	
+	/// Returns the JSON Array
+	public func toJSON() -> [[String : AnyObject]]? {
+		return Mapper().toJSONArray(self)
+	}
+	
+}
+
+public extension Set where Element : protocol<Mappable, Hashable> {
+	
+	/// Initializes a set from a JSON String
+	public init?(JSONString: String) {
+		if let obj: Set<Element> = Mapper().mapSet(JSONString) {
+			self = obj
+		}
+		else {
+			return nil
+		}
+	}
+	
+	/// Initializes a set from JSON
+	public init?(JSONArray: [[String : AnyObject]]?) {
+		if let obj: Set<Element> = Mapper().mapSet(JSONArray) {
+			self = obj
+		}
+		else {
+			return nil
+		}
+	}
+	
+	/// Returns the JSON Set
+	public func toJSON() -> [[String : AnyObject]]? {
+		return Mapper().toJSONSet(self)
+	}
+	
+}

--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -8,11 +8,6 @@
 
 import Foundation
 
-public protocol Mappable {
-	init?(_ map: Map)
-	mutating func mapping(map: Map)
-}
-
 public enum MappingType {
 	case FromJSON
 	case ToJSON

--- a/ObjectMapperTests/MappableExtensionsTests.swift
+++ b/ObjectMapperTests/MappableExtensionsTests.swift
@@ -1,0 +1,106 @@
+//
+//  MappableExtensionsTests.swift
+//  ObjectMapper
+//
+//  Created by Scott Hoyt on 10/25/15.
+//  Copyright © 2015 hearst. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import ObjectMapper
+import Nimble
+
+struct TestMappable : Mappable, Equatable, Hashable {
+	static let valueForString = "This string should work"
+	static let workingJSONString = "{ \"value\" : \"\(valueForString)\" }"
+	static let workingJSON: [String: AnyObject] = ["value" : valueForString]
+	static let workingJSONArrayString = "[\(workingJSONString)]"
+	
+	var value: String?
+	
+	init() {}
+	init?(_ map: Map) {	}
+	
+	mutating func mapping(map: Map) {
+		value <- map["value"]
+	}
+	
+	var hashValue: Int {
+		if let value = value {
+			return value.hashValue
+		}
+		return [].hashValue
+	}
+}
+
+func ==(lhs: TestMappable, rhs: TestMappable) -> Bool {
+	return lhs.value == rhs.value
+}
+
+class MappableExtensionsTests: XCTestCase {
+	
+	var testMappable: TestMappable!
+	
+	override func setUp() {
+		super.setUp()
+		testMappable = TestMappable()
+		testMappable.value = TestMappable.valueForString
+	}
+	
+	func testInitFailsWithNilString() {
+		expect(TestMappable(JSONString: nil)).to(beNil())
+	}
+	
+	func testInitFailsWithNilJSON() {
+		expect(TestMappable(JSON: nil)).to(beNil())
+	}
+	
+	func testInitFromString() {
+		let mapped = TestMappable(JSONString: TestMappable.workingJSONString)
+		expect(mapped).toNot(beNil())
+		expect(mapped?.value).to(equal(TestMappable.valueForString))
+	}
+	
+	func testToJSONAndBack() {
+		let mapped = TestMappable(JSON: testMappable.toJSON())
+		expect(mapped).to(equal(testMappable))
+	}
+	
+	func testArrayInitFailsWithNilString() {
+		expect([TestMappable](JSONString: nil)).to(beNil())
+	}
+	
+	func testArrayInitFailsWithNilArray() {
+		expect([TestMappable](JSONArray: nil)).to(beNil())
+	}
+	
+	func testArrayFromString() {
+		let mapped = [TestMappable](JSONString: TestMappable.workingJSONArrayString)!
+		expect(mapped).to(equal([testMappable]))
+	}
+	
+	func testArrayToJSONAndBack() {
+		let mapped = [TestMappable](JSONArray: [testMappable].toJSON())
+		expect(mapped).to(equal([testMappable]))
+	}
+	
+	func testSetInitFailsWithEmptyString() {
+		expect(Set<TestMappable>(JSONString: "")).to(beNil())
+	}
+	
+	func testSetInitFailsWithNilArray() {
+		expect(Set<TestMappable>(JSONArray: nil)).to(beNil())
+	}
+	
+	func testSetFromString() {
+		let mapped = Set<TestMappable>(JSONString: TestMappable.workingJSONArrayString)!
+		expect(mapped).to(equal(Set<TestMappable>([testMappable])))
+	}
+	
+	func testSetToJSONAndBack() {
+		let mapped = Set<TestMappable>(JSONArray: Set([testMappable]).toJSON())
+		expect(mapped).to(equal([testMappable]))
+	}
+
+}


### PR DESCRIPTION
Thanks again for the great framework! Because of the nature of the changes, I included a pretty lengthy discussion here. Since this mostly reflects my design ideas and not substantial functionality improvement, feel free to reject this PR if it doesn't fit your goals, but I thought making this available to you was the least I could do to say thanks. :) I don't offhand know why this can't be automatically merged if you accept though. I don't think I made any hard-to-merge changes.

# Mappable Extensions

## Purpose

This PR incorporates the `init` and `toJSON` additions to `Mappable`, `Array<Mappable>`, and `Set<Mappable>` that I implemented for a recent project. I believe this interface is a bit more _Swifty_ than the current interface and allows better encapsulation of the **ObjectMapper** framework.

## Changes

By using protocol extensions, I added failable initializers and a `toJSON()` for `Mappable`, `Array<Mappable>`, and `Set<Mappable>`. At a high level, these changes allow for the following use cases.

    class MyMappable : Mappable, Hashable { ... }

    let myMappable = MyMappable(JSONString: aJSONString)
    let myMappable = MyMappable(JSON: aJSONDictionary)

    let myArray = [MyMappable](JSONString: aJSONArrayString)
    let myArray = [MyMappable](JSONArray: aJSONDictionaryArray)

    let mySet = Set<MyMappable>(JSONString: aJSONArrayString)
    let myset = Set<MyMappable>(JSONArray: aJSONDictionaryArray)

    let myMappableJSON = myMappable?.toJSON()
    let myArrayJSON = myArray?.toJSON()
    let mySetJSON = mySet?.toJSON()

## Discussion

As I have been working on this project, I have found that ObjectMapper has made writing my JSON-based API client so much easier. However, the framework dependency had to be spread to a few places that I would prefer it didn't. This was mostly the API client classes as well as the model-testing classes. Since all my JSON-mapped model objects already had to include the framework to implement `Mappable`, this seemed like the ideal place to encapsulate all the framework knowledge. By removing these dependencies and localizing the knowledge to the model objects, changing mapping libraries or even serialization methodology in the future should be easier to accomplish. This functionality could be further abstracted into protocols (e.g. `JSONConvertible`) to make testability in the API client easier, though I didn't take it that far.

In addition, since Swift added failable initializers, the Apple frameworks have moved more towards this pattern instead of the factory pattern that has been prevalent. It seemed like a nice idea to implement this pattern for ObjectMapper as well for stylistic reasons. This was made quite a bit easier with protocol extensions.

## Caveats

I made the decision to not implement initializers that take `AnyObject?` arguments. While this might make sense for the calls to `Mapper` given the context, it seemed a bit misleading to provide such a vaguely typed initializer by default since there's a relatively small subset of the `AnyObject?` type that could successfully initialize an object. It also seemed to be fighting the type system a bit. I think a better solution is to leave that type check in the code that is initializing the `Mappable` where checking for having the right type to initialize is maybe more appropriate.

I was not able to extend this philosophy to `Dictionary<String, AnyObject>`. This was primarily due to the current limitation of not being able to conditionally extend protocols with non-protocol type requirements. There could be a way around this, but it escaped me.

I would also prefer to include the new initializers in the `Mappable` protocol as well so that implementers could chose to override the default functionality. However, I couldn't figure out how to do that without adding a bunch of `required` inits. Again, there could be a way around this. Also, if this functionality was refactored out into a `JSONConvertible` protocol, that would largely alleviate this concern. However, with current limitations of protocol extensions, you'd then run into the problem of not being able to do something like:

    extension Array : JSONConvertible where Element : JSONConvertible { ... }

## Testing

Tests are included to provide 100% coverage of the new extensions.
