### PR TITLE
Allow mapArray to map to an empty array

### DIFF
--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -136,7 +136,7 @@ public final class Mapper<N: Mappable> {
 		// map every element in JSON array to type N
 		let result = JSONArray.flatMap(map)
 		if result.isEmpty {
-			return nil
+			return []
 		}
 		
 		return result

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -256,6 +256,15 @@ class ObjectMapperTests: XCTestCase {
 		expect(students?[0].name).to(equal(name1))
 	}
 
+	func testMapArrayJSONWithEmptyArray() {
+		let JSONString = "[]"
+
+		let students = Mapper<Student>().mapArray(JSONString)
+
+		expect(students).to(beEmpty())
+		expect(students?.count).to(equal(0))
+	}
+
 	func testArrayOfCustomObjects(){
 		let percentage1: Double = 0.1
 		let percentage2: Double = 1792.41


### PR DESCRIPTION
This is a fix for https://github.com/Hearst-DD/ObjectMapper/issues/262.

In ObjectMapper 0.19 the array mapping behavior changed to map an
empty JSON array to nil. Previous versions mapped an empty JSON
array to an empty swift array.