### PR TITLE
Optional Array and Dictionary types defaulting to nil instead of empty collection

### DIFF
--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -221,23 +221,23 @@ public func <- <T: TransformType>(inout left: [String: T.Object]!, right: (Map, 
 	}
 }
 
-private func fromJSONArrayWithTransform<T: TransformType>(input: AnyObject?, transform: T) -> [T.Object] {
+private func fromJSONArrayWithTransform<T: TransformType>(input: AnyObject?, transform: T) -> [T.Object]? {
 	if let values = input as? [AnyObject] {
 		return values.flatMap { value in
 			return transform.transformFromJSON(value)
 		}
 	} else {
-		return []
+		return nil
 	}
 }
 
-private func fromJSONDictionaryWithTransform<T: TransformType>(input: AnyObject?, transform: T) -> [String: T.Object] {
+private func fromJSONDictionaryWithTransform<T: TransformType>(input: AnyObject?, transform: T) -> [String: T.Object]? {
 	if let values = input as? [String: AnyObject] {
 		return values.filterMap { value in
 			return transform.transformFromJSON(value)
 		}
 	} else {
-		return [:]
+		return nil
 	}
 }
 


### PR DESCRIPTION
I've been unit testing the fromJSON and toJSON of my models and I had an issue where an optional array would always have value `[]` instead of being `nil`.

```swift
struct Designer: Mappable {

  var identifier: Int?
  var name: String?
  var dresses: [Dress]?

  init(identifier: Int? = nil, name: String? = nil, dresses: [Dress]? = nil) {
    self.identifier = identifier
    self.name = name
    self.dresses = dresses
  }

  // MARK: JSON
  init?(_ map: Map) { }

  mutating func mapping(map: Map) {
    identifier <- map["id"]
    name <- map["name"]
    dresses <- map["dresses"]
  }

}
```

Even though dresses is `[Dress]?`, when the JSON has no `dresses` key it would default to `[]`, hence when converting back to JSON it would serialize to `dresses: []`, not generating the same JSON that was passed in the first place.

PSA: I might be missing some edge cases where `[]` and `[:]` actually make sense as default values.