### PR TITLE
Objects with mappable properties are no longer overwritten when using…

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		6100B1C01BD76A030011114A /* NestedArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6100B1BF1BD76A020011114A /* NestedArrayTests.swift */; };
 		6A05B7B01BE274BE00F19B53 /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A05B7A61BE274BE00F19B53 /* ObjectMapper.framework */; };
 		6A05B7BD1BE274E800F19B53 /* ObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AAC8F7B19F03C2900E7A677 /* ObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6A0BF1FF1C0B53470083D1AF /* ReferenceTypesFromJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0BF1FE1C0B53470083D1AF /* ReferenceTypesFromJSON.swift */; };
+		6A0BF2001C0B53470083D1AF /* ReferenceTypesFromJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0BF1FE1C0B53470083D1AF /* ReferenceTypesFromJSON.swift */; };
+		6A0BF2011C0B53470083D1AF /* ReferenceTypesFromJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0BF1FE1C0B53470083D1AF /* ReferenceTypesFromJSON.swift */; };
 		6A2AD0451B2C786C0097E150 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC419F048FE00E7A677 /* Mapper.swift */; };
 		6A2AD0461B2C786C0097E150 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC519F048FE00E7A677 /* Operators.swift */; };
 		6A2AD0471B2C786C0097E150 /* FromJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC319F048FE00E7A677 /* FromJSON.swift */; };
@@ -143,6 +146,7 @@
 		6100B1BF1BD76A020011114A /* NestedArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedArrayTests.swift; sourceTree = "<group>"; };
 		6A05B7A61BE274BE00F19B53 /* ObjectMapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectMapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A05B7AF1BE274BE00F19B53 /* ObjectMapper-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ObjectMapper-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6A0BF1FE1C0B53470083D1AF /* ReferenceTypesFromJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferenceTypesFromJSON.swift; sourceTree = "<group>"; };
 		6A2AD03D1B2C78540097E150 /* ObjectMapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectMapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A3774331A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BasicTypesTestsToJSON.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6A51372B1AADDE2700B82516 /* DateFormatterTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateFormatterTransform.swift; sourceTree = "<group>"; };
@@ -293,6 +297,7 @@
 				CD44374C1AAE9C1100A271BA /* NestedKeysTests.swift */,
 				6100B1BF1BD76A020011114A /* NestedArrayTests.swift */,
 				6AAC8F8519F03C2900E7A677 /* ObjectMapperTests.swift */,
+				6A0BF1FE1C0B53470083D1AF /* ReferenceTypesFromJSON.swift */,
 				6AAC8F8319F03C2900E7A677 /* Supporting Files */,
 			);
 			path = ObjectMapperTests;
@@ -630,6 +635,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6AC692411BE3FD45004C119A /* BasicTypes.swift in Sources */,
+				6A0BF2011C0B53470083D1AF /* ReferenceTypesFromJSON.swift in Sources */,
 				6AC692421BE3FD45004C119A /* BasicTypesTestsFromJSON.swift in Sources */,
 				6AC692431BE3FD45004C119A /* BasicTypesTestsToJSON.swift in Sources */,
 				6AC692441BE3FD45004C119A /* CustomTransformTests.swift in Sources */,
@@ -684,6 +690,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A6AEB961A93874F002573D3 /* BasicTypesTestsFromJSON.swift in Sources */,
+				6A0BF1FF1C0B53470083D1AF /* ReferenceTypesFromJSON.swift in Sources */,
 				CD44374D1AAE9C1100A271BA /* NestedKeysTests.swift in Sources */,
 				6A3774341A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift in Sources */,
 				6A51372F1AADE12C00B82516 /* CustomTransformTests.swift in Sources */,
@@ -718,6 +725,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CD1603261AC02480000CD69A /* BasicTypesTestsFromJSON.swift in Sources */,
+				6A0BF2001C0B53470083D1AF /* ReferenceTypesFromJSON.swift in Sources */,
 				CD1603291AC02480000CD69A /* NestedKeysTests.swift in Sources */,
 				CD1603251AC02480000CD69A /* BasicTypes.swift in Sources */,
 				CD16032A1AC02480000CD69A /* ObjectMapperTests.swift in Sources */,

--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -50,20 +50,30 @@ internal final class FromJSON {
 	}
 
 	/// Mappable object
-	class func object<N: Mappable>(inout field: N, object: AnyObject?) {
-		if let value: N = Mapper().map(object) {
+	class func object<N: Mappable>(inout field: N, object: Map) {
+		if object.toObject {
+			Mapper().map(object.currentValue, toObject: field)
+		} else if let value: N = Mapper().map(object.currentValue) {
 			field = value
 		}
 	}
 
 	/// Optional Mappable Object
-	class func optionalObject<N: Mappable>(inout field: N?, object: AnyObject?) {
-		field = Mapper().map(object)
+	class func optionalObject<N: Mappable>(inout field: N?, object: Map) {
+		if let field = field where object.toObject {
+			Mapper().map(object.currentValue, toObject: field)
+		} else {
+			field = Mapper().map(object.currentValue)
+		}
 	}
 
 	/// Implicitly unwrapped Optional Mappable Object
-	class func optionalObject<N: Mappable>(inout field: N!, object: AnyObject?) {
-		field = Mapper().map(object)
+	class func optionalObject<N: Mappable>(inout field: N!, object: Map) {
+		if let field = field where object.toObject {
+			Mapper().map(object.currentValue, toObject: field)
+		} else {
+			field = Mapper().map(object.currentValue)
+		}
 	}
 
 	/// mappable object array

--- a/ObjectMapper/Core/Map.swift
+++ b/ObjectMapper/Core/Map.swift
@@ -37,13 +37,16 @@ public final class Map {
 	var currentValue: AnyObject?
 	var currentKey: String?
 	var keyIsNested = false
+
+	let toObject: Bool // indicates whether the mapping is being applied to an existing object
 	
 	/// Counter for failing cases of deserializing values to `let` properties.
 	private var failedCount: Int = 0
 	
-	public init(mappingType: MappingType, JSONDictionary: [String : AnyObject]) {
+	public init(mappingType: MappingType, JSONDictionary: [String : AnyObject], toObject: Bool = false) {
 		self.mappingType = mappingType
 		self.JSONDictionary = JSONDictionary
+		self.toObject = toObject
 	}
 	
 	/// Sets the current mapper value and key.

--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -65,7 +65,7 @@ public final class Mapper<N: Mappable> {
 	/// Maps a JSON dictionary to an existing object that conforms to Mappable.
 	/// Usefull for those pesky objects that have crappy designated initializers like NSManagedObject
 	public func map(JSONDictionary: [String : AnyObject], var toObject object: N) -> N {
-		let map = Map(mappingType: .FromJSON, JSONDictionary: JSONDictionary)
+		let map = Map(mappingType: .FromJSON, JSONDictionary: JSONDictionary, toObject: true)
 		object.mapping(map)
 		return object
 	}

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -258,7 +258,7 @@ private func toJSONDictionaryWithTransform<T: TransformType>(input: [String: T.O
 /// Object conforming to Mappable
 public func <- <T: Mappable>(inout left: T, right: Map) {
     if right.mappingType == MappingType.FromJSON {
-        FromJSON.object(&left, object: right.currentValue)
+        FromJSON.object(&left, object: right)
     } else {
 		ToJSON.object(left, map: right)
     }
@@ -267,7 +267,7 @@ public func <- <T: Mappable>(inout left: T, right: Map) {
 /// Optional Mappable objects
 public func <- <T: Mappable>(inout left: T?, right: Map) {
     if right.mappingType == MappingType.FromJSON {
-        FromJSON.optionalObject(&left, object: right.currentValue)
+        FromJSON.optionalObject(&left, object: right)
     } else {
 		ToJSON.optionalObject(left, map: right)
     }
@@ -276,7 +276,7 @@ public func <- <T: Mappable>(inout left: T?, right: Map) {
 /// Implicitly unwrapped optional Mappable objects
 public func <- <T: Mappable>(inout left: T!, right: Map) {
 	if right.mappingType == MappingType.FromJSON {
-		FromJSON.optionalObject(&left, object: right.currentValue)
+		FromJSON.optionalObject(&left, object: right)
 	} else {
 		ToJSON.optionalObject(left, map: right)
 	}

--- a/ObjectMapperTests/ReferenceTypesFromJSON.swift
+++ b/ObjectMapperTests/ReferenceTypesFromJSON.swift
@@ -1,0 +1,69 @@
+//
+//  ReferenceTypesFromJSON.swift
+//  ObjectMapper
+//
+//  Created by Tristan Himmelman on 2015-11-29.
+//  Copyright © 2015 hearst. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import ObjectMapper
+
+class ReferenceTypesTestsFromJSON: XCTestCase {
+	
+	override func setUp() {
+		super.setUp()
+		// Put setup code here. This method is called before the invocation of each test method in the class.
+	}
+	
+	override func tearDown() {
+		// Put teardown code here. This method is called after the invocation of each test method in the class.
+		super.tearDown()
+	}
+	
+	func testMappingPersonFromJSON(){
+		let name = "ASDF"
+		let spouseName = "HJKL"
+		let JSONString = "{\"name\" : \"\(name)\", \"spouse\" : {\"name\" : \"\(spouseName)\"}}"
+		
+		let mappedObject = Mapper<Person>().map(JSONString)
+		
+		XCTAssertNotNil(mappedObject)
+		XCTAssertEqual(mappedObject?.name, name)
+		XCTAssertEqual(mappedObject?.spouse?.name, spouseName)
+	}
+	
+	func testUpdatingPersonFromJSON(){
+		let name = "ASDF"
+		let initialSpouseName = "HJKL"
+		let updatedSpouseName = "QWERTY"
+		let initialJSONString = "{\"name\" : \"\(name)\", \"spouse\" : {\"name\" : \"\(initialSpouseName)\"}}"
+		let updatedJSONString = "{\"name\" : \"\(name)\", \"spouse\" : {\"name\" : \"\(updatedSpouseName)\"}}"
+		
+		let mappedObject = Mapper<Person>().map(initialJSONString)
+		let initialSpouse = mappedObject?.spouse
+		
+		XCTAssertNotNil(mappedObject)
+		
+		let updatedObject = Mapper<Person>().map(updatedJSONString, toObject: mappedObject!)
+		
+		XCTAssert(initialSpouse === updatedObject.spouse, "Expected mapping to update the existing object not create a new one")
+		XCTAssertEqual(updatedObject.spouse?.name, updatedSpouseName)
+		XCTAssertEqual(initialSpouse?.name,	updatedSpouseName)
+	}
+}
+
+class Person: Mappable {
+	var name: String?
+	var spouse: Person?
+	
+	required init?(_ map: Map) {
+		
+	}
+	
+	func mapping(map: Map) {
+		name	<- map["name"]
+		spouse	<- map["spouse"]
+	}
+}


### PR DESCRIPTION
… the map toObject function

(Arrays and Dictionaries still need to be fixed)