### PR TITLE
Allow handling polymorphic object

### DIFF
--- a/ObjectMapper/Core/Map.swift
+++ b/ObjectMapper/Core/Map.swift
@@ -33,7 +33,7 @@ import Foundation
 public final class Map {
 	public let mappingType: MappingType
 	
-	var JSONDictionary: [String : AnyObject] = [:]
+	public var JSONDictionary: [String : AnyObject] = [:]
 	public var currentValue: AnyObject?
 	var currentKey: String?
 	var keyIsNested = false


### PR DESCRIPTION
To be able to handle polymorphic objects the JSONDictionary should be
available. Otherwise the map function doesn't work.