### PR TITLE
Prevent mappable object array from being overwritten with nil value

### DIFF
--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -85,12 +85,16 @@ internal final class FromJSON {
 
 	/// optional mappable object array
 	class func optionalObjectArray<N: Mappable>(inout field: Array<N>?, map: Map) {
-		field = Mapper().mapArray(map.currentValue)
+		if let objects: Array<N> = Mapper().mapArray(map.currentValue) {
+			field = objects
+		}
 	}
 
 	/// Implicitly unwrapped optional mappable object array
 	class func optionalObjectArray<N: Mappable>(inout field: Array<N>!, map: Map) {
-		field = Mapper().mapArray(map.currentValue)
+		if let objects: Array<N> = Mapper().mapArray(map.currentValue) {
+			field = objects
+		}
 	}
 	
 	/// mappable object array

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -538,6 +538,24 @@ class ObjectMapperTests: XCTestCase {
 		XCTAssertEqual(arrayTest2?.twoDimensionalArray?[0][0].base, arrayTest?.twoDimensionalArray?[0][0].base)
 		XCTAssertEqual(arrayTest2?.twoDimensionalArray?[0][1].base, arrayTest?.twoDimensionalArray?[0][1].base)
 	}
+
+	func testShouldPreventOverwritingMappableProperty() {
+		let json: [String: AnyObject] = [
+			"name": "Entry 1",
+			"bigList": [["name": "item 1"], ["name": "item 2"], ["name": "item 3"]]
+		]
+		let model = CachedModel()
+		Mapper().map(json, toObject: model)
+
+		XCTAssertEqual(model.name, "Entry 1")
+		XCTAssertEqual(model.bigList?.count, 3)
+
+		let json2: [String: AnyObject] = ["name": "Entry 1"]
+		Mapper().map(json2, toObject: model)
+
+		XCTAssertEqual(model.name, "Entry 1")
+		XCTAssertEqual(model.bigList?.count, 3)
+	}
 }
 
 class Response<T: Mappable>: Mappable {
@@ -812,6 +830,30 @@ class ArrayTest: Mappable {
 	
 	func mapping(map: Map) {
 		twoDimensionalArray <- map["twoDimensionalArray"]
+	}
+}
+
+class CachedModel: Mappable {
+	var name: String?
+	var bigList: [CachedItem]?
+
+	init() {}
+
+	required init?(_ map: Map){}
+
+	func mapping(map: Map) {
+		name <- map["name"]
+		bigList <- map["bigList"]
+	}
+}
+
+struct CachedItem: Mappable {
+	var name: String?
+
+	init?(_ map: Map){}
+
+	mutating func mapping(map: Map) {
+		name <- map["name"]
 	}
 }
 


### PR DESCRIPTION
All basic type properties are not written if the value is nil; however, this is not the case with mappable object array. The patch adds an `if let` check before assigning a value to mappable object array property. Fixes #333.