### PR TITLE
[Immutable] Make init throw + Transform & Mappable support

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -82,6 +82,9 @@
 		891804CE1C122AF000E5C3EE /* MappableTypesWithTransformsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891804CC1C122AF000E5C3EE /* MappableTypesWithTransformsTests.swift */; };
 		891804CF1C122AF000E5C3EE /* MappableTypesWithTransformsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891804CC1C122AF000E5C3EE /* MappableTypesWithTransformsTests.swift */; };
 		BC1E7F371ABC44C000F9B1CF /* EnumTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1E7F361ABC44C000F9B1CF /* EnumTransform.swift */; };
+		C0873D5E1C698657008344EE /* ImmutableObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0873D5D1C698657008344EE /* ImmutableObjectTests.swift */; };
+		C0873D5F1C698658008344EE /* ImmutableObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0873D5D1C698657008344EE /* ImmutableObjectTests.swift */; };
+		C0873D601C698658008344EE /* ImmutableObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0873D5D1C698657008344EE /* ImmutableObjectTests.swift */; };
 		CD16030A1AC023D6000CD69A /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD1602FF1AC023D5000CD69A /* ObjectMapper.framework */; };
 		CD1603181AC02437000CD69A /* ObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AAC8F7B19F03C2900E7A677 /* ObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD1603191AC02451000CD69A /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC419F048FE00E7A677 /* Mapper.swift */; };
@@ -190,6 +193,7 @@
 		6ACB15D11BC7F1D0006C029C /* Map.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Map.swift; sourceTree = "<group>"; };
 		891804CC1C122AF000E5C3EE /* MappableTypesWithTransformsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MappableTypesWithTransformsTests.swift; sourceTree = "<group>"; };
 		BC1E7F361ABC44C000F9B1CF /* EnumTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumTransform.swift; sourceTree = "<group>"; };
+		C0873D5D1C698657008344EE /* ImmutableObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmutableObjectTests.swift; sourceTree = "<group>"; };
 		CD1602FF1AC023D5000CD69A /* ObjectMapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectMapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD1603091AC023D6000CD69A /* ObjectMapper-MacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ObjectMapper-MacTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD44374C1AAE9C1100A271BA /* NestedKeysTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NestedKeysTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -320,6 +324,7 @@
 				6A412A231BB0DA26001C3F67 /* PerformanceTests.swift */,
 				CD44374C1AAE9C1100A271BA /* NestedKeysTests.swift */,
 				6100B1BF1BD76A020011114A /* NestedArrayTests.swift */,
+				C0873D5D1C698657008344EE /* ImmutableObjectTests.swift */,
 				6AAC8F8519F03C2900E7A677 /* ObjectMapperTests.swift */,
 				3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */,
 				6A0BF1FE1C0B53470083D1AF /* ToObjectTests.swift */,
@@ -664,6 +669,7 @@
 			files = (
 				6AA1F66F1BE9921C006EF513 /* MappableExtensionsTests.swift in Sources */,
 				891804CF1C122AF000E5C3EE /* MappableTypesWithTransformsTests.swift in Sources */,
+				C0873D601C698658008344EE /* ImmutableObjectTests.swift in Sources */,
 				6AA1F66B1BE94687006EF513 /* ClassClusterTests.swift in Sources */,
 				6AA1F66C1BE94687006EF513 /* PerformanceTests.swift in Sources */,
 				6AC692411BE3FD45004C119A /* BasicTypes.swift in Sources */,
@@ -725,6 +731,7 @@
 			files = (
 				3BAD2C101BDDC0B000E6B203 /* MappableExtensionsTests.swift in Sources */,
 				891804CD1C122AF000E5C3EE /* MappableTypesWithTransformsTests.swift in Sources */,
+				C0873D5E1C698657008344EE /* ImmutableObjectTests.swift in Sources */,
 				6A6AEB961A93874F002573D3 /* BasicTypesTestsFromJSON.swift in Sources */,
 				6A0BF1FF1C0B53470083D1AF /* ToObjectTests.swift in Sources */,
 				CD44374D1AAE9C1100A271BA /* NestedKeysTests.swift in Sources */,
@@ -765,6 +772,7 @@
 			files = (
 				3BAD2C111BDDC0B000E6B203 /* MappableExtensionsTests.swift in Sources */,
 				891804CE1C122AF000E5C3EE /* MappableTypesWithTransformsTests.swift in Sources */,
+				C0873D5F1C698658008344EE /* ImmutableObjectTests.swift in Sources */,
 				6AA1F66D1BE9468D006EF513 /* NestedArrayTests.swift in Sources */,
 				6A412A181BAC830B001C3F67 /* ClassClusterTests.swift in Sources */,
 				CD1603261AC02480000CD69A /* BasicTypesTestsFromJSON.swift in Sources */,

--- a/ObjectMapper.xcodeproj/xcshareddata/xcschemes/ObjectMapper-iOS.xcscheme
+++ b/ObjectMapper.xcodeproj/xcshareddata/xcschemes/ObjectMapper-iOS.xcscheme
@@ -37,7 +37,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/ObjectMapper/Core/Map.swift
+++ b/ObjectMapper/Core/Map.swift
@@ -68,8 +68,11 @@ public final class Map {
 		
 		return self
 	}
-	
-	// MARK: Immutable Mapping
+}
+
+// MARK: Immutable Mapping
+
+public extension Map {
 	
 	public func value<T>() -> T? {
 		return currentValue as? T
@@ -82,11 +85,88 @@ public final class Map {
 	/// Returns current JSON value of type `T` if it is existing, or returns a
 	/// unusable proxy value for `T` and collects failed count.
 	public func valueOrFail<T>() throws -> T {
-		if let value: T = value() {
-			return value
-		} else {
+		guard let value: T = value() else {
 			throw MapperError.error
 		}
+		return value
+	}
+	
+	/// Object of Basic type with Transform
+	public func valueOrFailWithTransform<Transform: TransformType>(transform: Transform) throws -> Transform.Object {
+		guard let value = transform.transformFromJSON(currentValue) else {
+			throw MapperError.error
+		}
+		return value
+	}
+	
+	/// Optional object of basic type with Transform
+	public func valueWithTransform<Transform: TransformType>(transform: Transform) -> Transform.Object? {
+		return transform.transformFromJSON(currentValue)
+	}
+	
+	/// Array of Basic type with Transform
+	public func valueOrFailWithTransform<Transform: TransformType>(transform: Transform) throws -> [Transform.Object] {
+		guard let values = fromJSONArrayWithTransform(currentValue, transform: transform) else {
+			throw MapperError.error
+		}
+		return values
+	}
+	
+	/// Optional array of Basic type with Transform
+	public func valueWithTransform<Transform: TransformType>(transform: Transform) -> [Transform.Object]? {
+		return fromJSONArrayWithTransform(currentValue, transform: transform)
+	}
+	
+	/// Dictionary of Basic type with Transform
+	public func valueOrFailWithTransform<Transform: TransformType>(transform: Transform) throws -> [String: Transform.Object] {
+		guard let values = fromJSONDictionaryWithTransform(currentValue, transform: transform) else {
+			throw MapperError.error
+		}
+		return values
+	}
+	
+	/// Optional dictionary of Basic type with Transform
+	public func valueWithTransform<Transform: TransformType>(transform: Transform) -> [String: Transform.Object]? {
+		return fromJSONDictionaryWithTransform(currentValue, transform: transform)
+	}
+	
+	/// Object conforming to Mappable
+	public func valueOrFail<T: Mappable>() throws -> T {
+		guard let object = Mapper<T>().map(currentValue) else {
+			throw MapperError.error
+		}
+		return object
+	}
+	
+	/// Optional Mappable objects
+	public func value<T: Mappable>() -> T? {
+		return Mapper<T>().map(currentValue)
+	}
+	
+	/// Dictionary of Mappable objects <String, T: Mappable>
+	public func valueOrFail<T: Mappable>() throws -> [String: T] {
+		guard let dictionary = Mapper<T>().mapDictionary(currentValue) else {
+			throw MapperError.error
+		}
+		return dictionary
+	}
+	
+	/// Optional Dictionary of Mappable object <String, T: Mappable>
+	public func value<T: Mappable>() -> [String: T]? {
+		return Mapper<T>().mapDictionary(currentValue)
+	}
+	
+	/// Array of Mappable objects
+	public func valueOrFail<T: Mappable>() throws -> [T] {
+		guard let array = Mapper<T>().mapArray(currentValue) else {
+			throw MapperError.error
+		}
+		return array
+	}
+	
+	/// Optional Array of Mappable objects
+	public func value<T: Mappable>() -> [T]? {
+		return Mapper<T>().mapArray(currentValue)
 	}
 }
 

--- a/ObjectMapper/Core/Map.swift
+++ b/ObjectMapper/Core/Map.swift
@@ -40,9 +40,6 @@ public final class Map {
 
 	let toObject: Bool // indicates whether the mapping is being applied to an existing object
 	
-	/// Counter for failing cases of deserializing values to `let` properties.
-	private var failedCount: Int = 0
-	
 	public init(mappingType: MappingType, JSONDictionary: [String : AnyObject], toObject: Bool = false) {
 		self.mappingType = mappingType
 		self.JSONDictionary = JSONDictionary
@@ -84,23 +81,12 @@ public final class Map {
 	
 	/// Returns current JSON value of type `T` if it is existing, or returns a
 	/// unusable proxy value for `T` and collects failed count.
-	public func valueOrFail<T>() -> T {
+	public func valueOrFail<T>() throws -> T {
 		if let value: T = value() {
 			return value
 		} else {
-			// Collects failed count
-			failedCount++
-			
-			// Returns dummy memory as a proxy for type `T`
-			let pointer = UnsafeMutablePointer<T>.alloc(0)
-			pointer.dealloc(0)
-			return pointer.memory
+			throw MapperError.error
 		}
-	}
-	
-	/// Returns whether the receiver is success or failure.
-	public var isValid: Bool {
-		return failedCount == 0
 	}
 }
 

--- a/ObjectMapper/Core/Mappable.swift
+++ b/ObjectMapper/Core/Mappable.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol Mappable {
-	init?(_ map: Map)
+	init(_ map: Map) throws
 	mutating func mapping(map: Map)
 }
 
@@ -20,20 +20,20 @@ public protocol MappableCluster: Mappable {
 public extension Mappable {
 	
 	/// Initializes object from a JSON String
-	public init?(JSONString: String) {
+	public init(JSONString: String) throws {
 		if let obj: Self = Mapper().map(JSONString) {
 			self = obj
 		} else {
-			return nil
+			throw MapperError.error
 		}
 	}
 	
 	/// Initializes object from a JSON Dictionary
-	public init?(JSON: [String : AnyObject]) {
+	public init(JSON: [String : AnyObject]) throws {
 		if let obj: Self = Mapper().map(JSON) {
 			self = obj
 		} else {
-			return nil
+			throw MapperError.error
 		}
 	}
 	

--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -28,6 +28,10 @@
 
 import Foundation
 
+public struct MapperError: ErrorType {
+	public static let error = MapperError()
+}
+
 public enum MappingType {
 	case FromJSON
 	case ToJSON
@@ -111,7 +115,7 @@ public final class Mapper<N: Mappable> {
 			}
 		}
 		
-		if var object = N(map) {
+		if var object = try? N(map) {
 			object.mapping(map)
 			return object
 		}

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -236,7 +236,7 @@ public func <- <Transform: TransformType>(inout left: [String: Transform.Object]
 	}
 }
 
-private func fromJSONArrayWithTransform<Transform: TransformType>(input: AnyObject?, transform: Transform) -> [Transform.Object]? {
+func fromJSONArrayWithTransform<Transform: TransformType>(input: AnyObject?, transform: Transform) -> [Transform.Object]? {
 	if let values = input as? [AnyObject] {
 		return values.flatMap { value in
 			return transform.transformFromJSON(value)
@@ -246,7 +246,7 @@ private func fromJSONArrayWithTransform<Transform: TransformType>(input: AnyObje
 	}
 }
 
-private func fromJSONDictionaryWithTransform<Transform: TransformType>(input: AnyObject?, transform: Transform) -> [String: Transform.Object]? {
+func fromJSONDictionaryWithTransform<Transform: TransformType>(input: AnyObject?, transform: Transform) -> [String: Transform.Object]? {
 	if let values = input as? [String: AnyObject] {
 		return values.filterMap { value in
 			return transform.transformFromJSON(value)
@@ -256,13 +256,13 @@ private func fromJSONDictionaryWithTransform<Transform: TransformType>(input: An
 	}
 }
 
-private func toJSONArrayWithTransform<Transform: TransformType>(input: [Transform.Object]?, transform: Transform) -> [Transform.JSON]? {
+func toJSONArrayWithTransform<Transform: TransformType>(input: [Transform.Object]?, transform: Transform) -> [Transform.JSON]? {
 	return input?.flatMap { value in
 		return transform.transformToJSON(value)
 	}
 }
 
-private func toJSONDictionaryWithTransform<Transform: TransformType>(input: [String: Transform.Object]?, transform: Transform) -> [String: Transform.JSON]? {
+func toJSONDictionaryWithTransform<Transform: TransformType>(input: [String: Transform.Object]?, transform: Transform) -> [String: Transform.JSON]? {
 	return input?.filterMap { value in
 		return transform.transformToJSON(value)
 	}

--- a/ObjectMapperTests/BasicTypes.swift
+++ b/ObjectMapperTests/BasicTypes.swift
@@ -131,7 +131,7 @@ class BasicTypes: Mappable {
 		
 	}
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 
 	}
 	
@@ -233,7 +233,7 @@ class TestCollectionOfPrimitives : Mappable {
 		
 	}
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	

--- a/ObjectMapperTests/ClassClusterTests.swift
+++ b/ObjectMapperTests/ClassClusterTests.swift
@@ -67,9 +67,9 @@ class Vehicle: MappableCluster {
 		if let type: String = map["type"].value() {
 			switch type {
 				case "car":
-					return Car(map)
+					return try? Car(map)
 				case "bus":
-					return Bus(map)
+					return try? Bus(map)
 				default:
 					return nil
 			}
@@ -77,7 +77,7 @@ class Vehicle: MappableCluster {
 		return nil
 	}
 
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	

--- a/ObjectMapperTests/CustomTransformTests.swift
+++ b/ObjectMapperTests/CustomTransformTests.swift
@@ -173,7 +173,7 @@ class Transforms: Mappable {
 		
 	}
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	

--- a/ObjectMapperTests/ImmutableObjectTests.swift
+++ b/ObjectMapperTests/ImmutableObjectTests.swift
@@ -1,0 +1,226 @@
+//
+//  ImmutableObjectTests.swift
+//  ObjectMapper
+//
+//  Created by Loïs Di Qual on 2/8/16.
+//  Copyright © 2016 hearst. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import ObjectMapper
+
+class ImmutableObjectTests: XCTestCase {
+	func testImmutableMappable() {
+		let mapper = Mapper<Immutable>()
+		let JSON = [
+			
+			// Basic types
+			"prop1": "Immutable!",
+			"prop2": 255,
+			"prop3": true,
+			// prop4 has a default value
+			
+			// String
+			"prop5": "prop5",
+			"prop6": "prop6",
+			"prop7": "prop7",
+			
+			// [String]
+			"prop8": ["prop8"],
+			"prop9": ["prop9"],
+			"prop10": ["prop10"],
+			
+			// [String: String]
+			"prop11": ["key": "prop11"],
+			"prop12": ["key": "prop12"],
+			"prop13": ["key": "prop13"],
+			
+			// Base
+			"prop14": ["base": "prop14"],
+			"prop15": ["base": "prop15"],
+			"prop16": ["base": "prop16"],
+			
+			// [Base]
+			"prop17": [["base": "prop17"]],
+			"prop18": [["base": "prop18"]],
+			"prop19": [["base": "prop19"]],
+			
+			// [String: Base]
+			"prop20": ["key": ["base": "prop20"]],
+			"prop21": ["key": ["base": "prop21"]],
+			"prop22": ["key": ["base": "prop22"]],
+		]
+		
+		let immutable: Immutable! = mapper.map(JSON)
+		XCTAssertNotNil(immutable)
+		XCTAssertEqual(immutable.prop1, "Immutable!")
+		XCTAssertEqual(immutable.prop2, 255)
+		XCTAssertEqual(immutable.prop3, true)
+		XCTAssertEqual(immutable.prop4, DBL_MAX)
+		
+		let JSON2 = [ "prop1": "prop1", "prop2": NSNull() ]
+		let immutable2 = mapper.map(JSON2)
+		XCTAssertNil(immutable2)
+		
+		let JSONFromObject = mapper.toJSON(immutable)
+		let objectFromJSON = mapper.map(JSONFromObject)
+		XCTAssertNotNil(objectFromJSON)
+		assertImmutableObjectsEqual(objectFromJSON!, immutable)
+	}
+}
+
+struct Immutable {
+	let prop1: String
+	let prop2: Int
+	let prop3: Bool
+	let prop4: Double
+	
+	let prop5: String
+	let prop6: String?
+	let prop7: String!
+	
+	let prop8: [String]
+	let prop9: [String]?
+	let prop10: [String]!
+	
+	let prop11: [String: String]
+	let prop12: [String: String]?
+	let prop13: [String: String]!
+	
+	let prop14: Base
+	let prop15: Base?
+	let prop16: Base!
+	
+	let prop17: [Base]
+	let prop18: [Base]?
+	let prop19: [Base]!
+	
+	let prop20: [String: Base]
+	let prop21: [String: Base]?
+	let prop22: [String: Base]!
+}
+
+extension Immutable: Mappable {
+	init(_ map: Map) throws {
+		prop1 = try map["prop1"].valueOrFail()
+		prop2 = try map["prop2"].valueOrFail()
+		prop3 = try map["prop3"].valueOrFail()
+		prop4 = map["prop4"].valueOr(DBL_MAX)
+		
+		prop5 = try map["prop5"].valueOrFailWithTransform(stringTransform)
+		prop6 = map["prop6"].valueWithTransform(stringTransform)
+		prop7 = map["prop7"].valueWithTransform(stringTransform)
+		
+		prop8 = try map["prop8"].valueOrFailWithTransform(stringTransform)
+		prop9 = map["prop9"].valueWithTransform(stringTransform)
+		prop10 = map["prop10"].valueWithTransform(stringTransform)
+		
+		prop11 = try map["prop11"].valueOrFailWithTransform(stringTransform)
+		prop12 = map["prop12"].valueWithTransform(stringTransform)
+		prop13 = map["prop13"].valueWithTransform(stringTransform)
+		
+		prop14 = try map["prop14"].valueOrFail()
+		prop15 = map["prop15"].value()
+		prop16 = map["prop16"].value()
+		
+		prop17 = try map["prop17"].valueOrFail()
+		prop18 = map["prop18"].value()
+		prop19 = map["prop19"].value()
+		
+		prop20 = try map["prop20"].valueOrFail()
+		prop21 = map["prop21"].value()
+		prop22 = map["prop22"].value()
+	}
+	
+	mutating func mapping(map: Map) {
+		switch map.mappingType {
+		case .FromJSON:
+			if let x = try? Immutable(map) {
+				self = x
+			}
+			
+		case .ToJSON:
+			var prop1 = self.prop1
+			var prop2 = self.prop2
+			var prop3 = self.prop3
+			var prop4 = self.prop4
+			var prop5 = self.prop5
+			var prop6 = self.prop6
+			var prop7 = self.prop7
+			var prop8 = self.prop8
+			var prop9 = self.prop9
+			var prop10 = self.prop10
+			var prop11 = self.prop11
+			var prop12 = self.prop12
+			var prop13 = self.prop13
+			var prop14 = self.prop14
+			var prop15 = self.prop15
+			var prop16 = self.prop16
+			var prop17 = self.prop17
+			var prop18 = self.prop18
+			var prop19 = self.prop19
+			var prop20 = self.prop20
+			var prop21 = self.prop21
+			var prop22 = self.prop22
+			
+			prop1 <- map["prop1"]
+			prop2 <- map["prop2"]
+			prop3 <- map["prop3"]
+			prop4 <- map["prop4"]
+			
+			prop5 <- (map["prop5"], stringTransform)
+			prop6 <- (map["prop6"], stringTransform)
+			prop7 <- (map["prop7"], stringTransform)
+			prop8 <- (map["prop8"], stringTransform)
+			prop9 <- (map["prop9"], stringTransform)
+			prop10 <- (map["prop10"], stringTransform)
+			prop11 <- (map["prop11"], stringTransform)
+			prop12 <- (map["prop12"], stringTransform)
+			prop13 <- (map["prop13"], stringTransform)
+			
+			prop14 <- map["prop14"]
+			prop15 <- map["prop15"]
+			prop16 <- map["prop16"]
+			prop17 <- map["prop17"]
+			prop18 <- map["prop18"]
+			prop19 <- map["prop19"]
+			prop20 <- map["prop20"]
+			prop21 <- map["prop21"]
+			prop22 <- map["prop22"]
+		}
+	}
+}
+
+let stringTransform = TransformOf<String, String>(fromJSON: { str -> String? in
+	return ""
+}) { str -> String? in
+	return ""
+}
+
+private func assertImmutableObjectsEqual(lhs: Immutable, _ rhs: Immutable) {
+	XCTAssertEqual(lhs.prop1, rhs.prop1)
+	XCTAssertEqual(lhs.prop2, rhs.prop2)
+	XCTAssertEqual(lhs.prop3, rhs.prop3)
+	XCTAssertEqual(lhs.prop4, rhs.prop4)
+	XCTAssertEqual(lhs.prop5, rhs.prop5)
+	XCTAssertEqual(lhs.prop6, rhs.prop6)
+	XCTAssertEqual(lhs.prop7, rhs.prop7)
+	XCTAssertEqual(lhs.prop8, rhs.prop8)
+	
+	// @hack: compare arrays and objects with their string representation.
+	XCTAssertEqual("\(lhs.prop9)", "\(rhs.prop9)")
+	XCTAssertEqual("\(lhs.prop10)", "\(rhs.prop10)")
+	XCTAssertEqual("\(lhs.prop11)", "\(rhs.prop11)")
+	XCTAssertEqual("\(lhs.prop12)", "\(rhs.prop12)")
+	XCTAssertEqual("\(lhs.prop13)", "\(rhs.prop13)")
+	XCTAssertEqual("\(lhs.prop14)", "\(rhs.prop14)")
+	XCTAssertEqual("\(lhs.prop15)", "\(rhs.prop15)")
+	XCTAssertEqual("\(lhs.prop16)", "\(rhs.prop16)")
+	XCTAssertEqual("\(lhs.prop17)", "\(rhs.prop17)")
+	XCTAssertEqual("\(lhs.prop18)", "\(rhs.prop18)")
+	XCTAssertEqual("\(lhs.prop19)", "\(rhs.prop19)")
+	XCTAssertEqual("\(lhs.prop20)", "\(rhs.prop20)")
+	XCTAssertEqual("\(lhs.prop21)", "\(rhs.prop21)")
+	XCTAssertEqual("\(lhs.prop22)", "\(rhs.prop22)")
+}

--- a/ObjectMapperTests/ImmutableObjectTests.swift
+++ b/ObjectMapperTests/ImmutableObjectTests.swift
@@ -59,6 +59,30 @@ class ImmutableObjectTests: XCTestCase {
 		XCTAssertEqual(immutable.prop3, true)
 		XCTAssertEqual(immutable.prop4, DBL_MAX)
 		
+		XCTAssertEqual(immutable.prop5, "prop5_TRANSFORMED")
+		XCTAssertEqual(immutable.prop6, "prop6_TRANSFORMED")
+		XCTAssertEqual(immutable.prop7, "prop7_TRANSFORMED")
+		
+		XCTAssertEqual(immutable.prop8, ["prop8_TRANSFORMED"])
+		XCTAssertEqual(immutable.prop9!, ["prop9_TRANSFORMED"])
+		XCTAssertEqual(immutable.prop10, ["prop10_TRANSFORMED"])
+		
+		XCTAssertEqual(immutable.prop11, ["key": "prop11_TRANSFORMED"])
+		XCTAssertEqual(immutable.prop12!, ["key": "prop12_TRANSFORMED"])
+		XCTAssertEqual(immutable.prop13, ["key": "prop13_TRANSFORMED"])
+		
+		XCTAssertEqual(immutable.prop14.base, "prop14")
+		XCTAssertEqual(immutable.prop15?.base, "prop15")
+		XCTAssertEqual(immutable.prop16.base, "prop16")
+		
+		XCTAssertEqual(immutable.prop17[0].base, "prop17")
+		XCTAssertEqual(immutable.prop18![0].base, "prop18")
+		XCTAssertEqual(immutable.prop19[0].base, "prop19")
+		
+		XCTAssertEqual(immutable.prop20["key"]!.base, "prop20")
+		XCTAssertEqual(immutable.prop21!["key"]!.base, "prop21")
+		XCTAssertEqual(immutable.prop22["key"]!.base, "prop22")
+		
 		let JSON2 = [ "prop1": "prop1", "prop2": NSNull() ]
 		let immutable2 = mapper.map(JSON2)
 		XCTAssertNil(immutable2)
@@ -192,10 +216,14 @@ extension Immutable: Mappable {
 	}
 }
 
+// Very simple transform, so we avoid comparing array of dates/enums/somethingcomplex in our unit tests
 let stringTransform = TransformOf<String, String>(fromJSON: { str -> String? in
-	return ""
+	guard let str = str else {
+		return nil
+	}
+	return "\(str)_TRANSFORMED"
 }) { str -> String? in
-	return ""
+	return str?.stringByReplacingOccurrencesOfString("_TRANSFORMED", withString: "", options: [], range: nil)
 }
 
 private func assertImmutableObjectsEqual(lhs: Immutable, _ rhs: Immutable) {

--- a/ObjectMapperTests/MappableExtensionsTests.swift
+++ b/ObjectMapperTests/MappableExtensionsTests.swift
@@ -19,7 +19,7 @@ struct TestMappable : Mappable, Equatable, Hashable {
 	var value: String?
 	
 	init() {}
-	init?(_ map: Map) {	}
+	init(_ map: Map) throws {	}
 	
 	mutating func mapping(map: Map) {
 		value <- map["value"]
@@ -48,14 +48,14 @@ class MappableExtensionsTests: XCTestCase {
 	}
 	
 	func testInitFromString() {
-		let mapped = TestMappable(JSONString: TestMappable.workingJSONString)
+		let mapped = try? TestMappable(JSONString: TestMappable.workingJSONString)
 		
 		XCTAssertNotNil(mapped)
 		XCTAssertEqual(mapped?.value, TestMappable.valueForString)
 	}
 	
 	func testToJSONAndBack() {
-		let mapped = TestMappable(JSON: testMappable.toJSON())
+		let mapped = try? TestMappable(JSON: testMappable.toJSON())
 		XCTAssertEqual(mapped, testMappable)
 	}
 	

--- a/ObjectMapperTests/MappableTypesWithTransformsTests.swift
+++ b/ObjectMapperTests/MappableTypesWithTransformsTests.swift
@@ -250,7 +250,7 @@ class MappableTypesWithTransformsTests: XCTestCase {
 		var I_winner: Team!
 		
 		required init(URI: String) { self.URI = URI }
-		required init?(_ map: Map) {}
+		required init(_ map: Map) throws {}
 		
 		func mapping(map: Map) {
 			players		<- (map["players"], RelationshipTransform<Player>())		// 2D Array with transform
@@ -285,7 +285,7 @@ class MappableTypesWithTransformsTests: XCTestCase {
 		var I_players: [Player]?
 		
 		required init(URI: String) { self.URI = URI }
-		required init?(_ map: Map) {}
+		required init(_ map: Map) throws {}
 		
 		func mapping(map: Map) {
 			players		<- (map["players"], RelationshipTransform<Player>())
@@ -296,7 +296,7 @@ class MappableTypesWithTransformsTests: XCTestCase {
 	
 	class Player: Mappable, URIInitiable {
 		required init(URI: String) {}
-		required init?(_ map: Map) {}
+		required init(_ map: Map) throws {}
 		
 		func mapping(map: Map) {}
 	}

--- a/ObjectMapperTests/NestedArrayTests.swift
+++ b/ObjectMapperTests/NestedArrayTests.swift
@@ -81,7 +81,7 @@ class NestedArray: Mappable {
 
 	var nestedObjectValue: Int?
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	
@@ -97,7 +97,7 @@ class NestedArray: Mappable {
 class NestedObject: Mappable {
 	var value: Int?
 	
-	required init?(_ map: Map){}
+	required init(_ map: Map) throws {}
 	
 	func mapping(map: Map) {
 		value	<- map["value"]

--- a/ObjectMapperTests/NestedKeysTests.swift
+++ b/ObjectMapperTests/NestedKeysTests.swift
@@ -163,7 +163,7 @@ class NestedKeys: Mappable {
 	var objectArray: [Object] = []
 	var objectDict: [String: Object] = [:]
 
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 
@@ -206,7 +206,7 @@ class NestedKeys: Mappable {
 class Object: Mappable, Equatable {
 	var value: Int = Int.min
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -561,7 +561,7 @@ class ObjectMapperTests: XCTestCase {
 class Response<T: Mappable>: Mappable {
 	var result: T?
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	
@@ -573,7 +573,7 @@ class Response<T: Mappable>: Mappable {
 class Status: Mappable {
 	var status: Int?
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 
@@ -586,7 +586,7 @@ class Plan: Mappable {
 	var tasks: [Task]?
 	var dictionaryOfTasks: [String: [Task]]?
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	
@@ -604,7 +604,7 @@ class Task: Mappable {
 		
 	}
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 
@@ -618,7 +618,7 @@ class TaskDictionary: Mappable {
 	var test: String?
 	var tasks: [String : Task]?
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	
@@ -640,7 +640,7 @@ struct Student: Mappable {
 		
 	}
 	
-	init?(_ map: Map){
+	init(_ map: Map) throws {
 		
 	}
 
@@ -681,7 +681,7 @@ class User: Mappable {
 		
 	}
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	
@@ -714,7 +714,7 @@ class Base: Mappable {
 		
 	}
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	
@@ -731,8 +731,8 @@ class Subclass: Base {
 		super.init()
 	}
 	
-	required init?(_ map: Map){
-		super.init(map)
+	required init(_ map: Map) throws {
+		try super.init(map)
 	}
 
 	override func mapping(map: Map) {
@@ -751,8 +751,8 @@ class GenericSubclass<T>: Base {
 		super.init()
 	}
 	
-	required init?(_ map: Map){
-		super.init(map)
+	required init(_ map: Map) throws {
+		try super.init(map)
 	}
 
 	override func mapping(map: Map) {
@@ -765,7 +765,7 @@ class GenericSubclass<T>: Base {
 class WithGenericArray<T: Mappable>: Mappable {
 	var genericItems: [T]?
 
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 
@@ -777,7 +777,7 @@ class WithGenericArray<T: Mappable>: Mappable {
 class ConcreteItem: Mappable {
 	var value: String?
 
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	
@@ -787,8 +787,8 @@ class ConcreteItem: Mappable {
 }
 
 class SubclassWithGenericArrayInSuperclass<Unused>: WithGenericArray<ConcreteItem> {
-	required init?(_ map: Map){
-		super.init(map)
+	required init(_ map: Map) throws {
+		try super.init(map)
 	}
 }
 
@@ -801,7 +801,7 @@ enum ExampleEnum: Int {
 class ExampleEnumArray: Mappable {
 	var enums: [ExampleEnum] = []
 
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 
@@ -813,7 +813,7 @@ class ExampleEnumArray: Mappable {
 class ExampleEnumDictionary: Mappable {
 	var enums: [String: ExampleEnum] = [:]
 
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 
@@ -826,7 +826,7 @@ class ArrayTest: Mappable {
 	
 	var twoDimensionalArray: Array<Array<Base>>?
 	
-	required init?(_ map: Map){}
+	required init(_ map: Map) throws {}
 	
 	func mapping(map: Map) {
 		twoDimensionalArray <- map["twoDimensionalArray"]
@@ -839,7 +839,7 @@ class CachedModel: Mappable {
 
 	init() {}
 
-	required init?(_ map: Map){}
+	required init(_ map: Map) throws {}
 
 	func mapping(map: Map) {
 		name <- map["name"]
@@ -850,7 +850,7 @@ class CachedModel: Mappable {
 struct CachedItem: Mappable {
 	var name: String?
 
-	init?(_ map: Map){}
+	init(_ map: Map) throws {}
 
 	mutating func mapping(map: Map) {
 		name <- map["name"]
@@ -865,21 +865,17 @@ struct Immutable: Equatable {
 }
 
 extension Immutable: Mappable {
-	init?(_ map: Map) {
-		prop1 = map["prop1"].valueOrFail()
-		prop2 = map["prop2"].valueOrFail()
-		prop3 = map["prop3"].valueOrFail()
+	init(_ map: Map) throws {
+		prop1 = try map["prop1"].valueOrFail()
+		prop2 = try map["prop2"].valueOrFail()
+		prop3 = try map["prop3"].valueOrFail()
 		prop4 = map["prop4"].valueOr(DBL_MAX)
-		
-		if !map.isValid {
-			return nil
-		}
 	}
 		
 	mutating func mapping(map: Map) {
 		switch map.mappingType {
 		case .FromJSON:
-			if let x = Immutable(map) {
+			if let x = try? Immutable(map) {
 				self = x
 			}
 			

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -490,25 +490,6 @@ class ObjectMapperTests: XCTestCase {
 		XCTAssertEqual(genericItems?[1].value, "value1")
 	}
 	
-	func testImmutableMappable() {
-		let mapper = Mapper<Immutable>()
-		let JSON = ["prop1": "Immutable!", "prop2": 255, "prop3": true ]
-
-		let immutable: Immutable! = mapper.map(JSON)
-		XCTAssertNotNil(immutable)
-		XCTAssertEqual(immutable.prop1, "Immutable!")
-		XCTAssertEqual(immutable.prop2, 255)
-		XCTAssertEqual(immutable.prop3, true)
-		XCTAssertEqual(immutable.prop4, DBL_MAX)
-
-		let JSON2 = [ "prop1": "prop1", "prop2": NSNull() ]
-		let immutable2 = mapper.map(JSON2)
-		XCTAssertNil(immutable2)
-
-		let JSONFromObject = mapper.toJSON(immutable)
-		XCTAssertEqual(mapper.map(JSONFromObject), immutable)
-	}
-	
 	func testArrayOfArrayOfMappable() {
 		let base1 = "1"
 		let base2 = "2"
@@ -855,47 +836,4 @@ struct CachedItem: Mappable {
 	mutating func mapping(map: Map) {
 		name <- map["name"]
 	}
-}
-
-struct Immutable: Equatable {
-	let prop1: String
-	let prop2: Int
-	let prop3: Bool
-	let prop4: Double
-}
-
-extension Immutable: Mappable {
-	init(_ map: Map) throws {
-		prop1 = try map["prop1"].valueOrFail()
-		prop2 = try map["prop2"].valueOrFail()
-		prop3 = try map["prop3"].valueOrFail()
-		prop4 = map["prop4"].valueOr(DBL_MAX)
-	}
-		
-	mutating func mapping(map: Map) {
-		switch map.mappingType {
-		case .FromJSON:
-			if let x = try? Immutable(map) {
-				self = x
-			}
-			
-		case .ToJSON:
-			var prop1 = self.prop1
-			var prop2 = self.prop2
-			var prop3 = self.prop3
-			var prop4 = self.prop4
-			
-			prop1 <- map["prop1"]
-			prop2 <- map["prop2"]
-			prop3 <- map["prop3"]
-			prop4 <- map["prop4"]
-		}
-	}
-}
-
-func ==(lhs: Immutable, rhs: Immutable) -> Bool {
-	return lhs.prop1 == rhs.prop1
-		&& lhs.prop2 == rhs.prop2
-		&& lhs.prop3 == rhs.prop3
-		&& lhs.prop4 == rhs.prop4
 }

--- a/ObjectMapperTests/PerformanceTests.swift
+++ b/ObjectMapperTests/PerformanceTests.swift
@@ -77,7 +77,7 @@ class Person: Mappable {
 		
 	}
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	
@@ -124,7 +124,7 @@ class PersonCluster: MappableCluster {
 		
 	}
 	
-	required init?(_ map: Map){
+	required init(_ map: Map) throws {
 		
 	}
 	

--- a/ObjectMapperTests/ToObjectTests.swift
+++ b/ObjectMapperTests/ToObjectTests.swift
@@ -80,7 +80,7 @@ class ToObjectTests: XCTestCase {
 		var spouse: Person?
 		var children: [String : Person]?
 		
-		required init?(_ map: Map) {
+		required init(_ map: Map) throws {
 			
 		}
 		


### PR DESCRIPTION
@tristanhimmelman 

Related to https://github.com/Hearst-DD/ObjectMapper/issues/383

This PR adds various improvements over the current immutable mapping support (see commented section in https://raw.githubusercontent.com/Hearst-DD/ObjectMapper/master/README.md)

## Summary of changes

### Immutable mapping

Immutable mapping can now be written like this:

```
class Base: Mappable {
    let base: String
    let date: NSDate

    init(_ map: Map) throws {
        base = try map["base"].valueOrFail()
        date = try map["date].valueWithTransformOrFail(DateTransform())
        // And a lot more
    }

    mutating func mapping(map: Map) {
        // unchanged
    }
}
```

This required the following change in the `Mappable` protocol:

```
public protocol Mappable {
--	init?(_ map: Map)
++   init(_ map: Map) throws
```

This has a couple advantages:
 - There's no more need to call `map.isValid` at the end of the initializer.
 - You can exit the initializer early if one of the mappings failed.
 - You can add custom validation logic and throw an error if the mapping doesn't fit your needs.
 - The library can be extended to throw meaningful errors (like `couldn't map attribute "base" with type "Base", payload: "123"`). As of now it just throws a very basic `ErrorType` subclass (`MappingError`)

### Transforms & Mappable

Added support for the following immutable mapping types. `valueOrFail()` throws, `value()` returns an optional.
 - Basic type T, with `T, [T], [String: T]`
 - Transforms mapping via `valueWithTransform/valueWithTransformOrFail`. `T, [T], [String: T]`
 - Mappable mapping, with `T, [T], [String: T]`.

### ImmutableObjectTests

Moved the small `Immutable` test from `ObjectMapperTests` to `ImmutableObjectTests` and added all cases that were covered in this PR. We might want to break it down into multiple tests, but I went for simplicity for this first draft.

## Discussion

@tristanhimmelman This PR's main goal is to kick off a conversation about immutable mapping. While I think the interface is acceptable, it's more meant to be a starting point to discuss how the library could be modified to support such a feature.

I'd love your input on the following points:
 - What do you think about the `init` change? Do you think it's acceptable to break the interface for such a feature?
 - How about `mapping()`? Right now it's really awkward to have to switch on the mapping type, create variables and map them with an `inout` operator. I was thinking about the following:
  - Only allow `JSON => object` mapping via `init(map: Mapping)` and drop the `<-` operator
  - Add a `->` operator in `mapping(map: Mapping)` and rename that method to `serialize()`.

Also, if you'd rather go with another process to discuss immutability changes, just let me know! Thank you :)