### PR TITLE
Update Map.swift for Swift 3

### DIFF
--- a/ObjectMapper/Core/Map.swift
+++ b/ObjectMapper/Core/Map.swift
@@ -90,7 +90,7 @@ public final class Map {
 			return value
 		} else {
 			// Collects failed count
-			failedCount++
+			failedCount = failedCount + 1
 			
 			// Returns dummy memory as a proxy for type `T`
 			let pointer = UnsafeMutablePointer<T>.alloc(0)


### PR DESCRIPTION
In preparation for Swift 3 -- `++` is deprecated: it will be removed in Swift 3 (https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md)