### PR TITLE
Fixed swift 3 warnings

### DIFF
--- a/ObjectMapper/Core/Map.swift
+++ b/ObjectMapper/Core/Map.swift
@@ -90,7 +90,7 @@ public final class Map {
 			return value
 		} else {
 			// Collects failed count
-			failedCount++
+			failedCount += 1
 			
 			// Returns dummy memory as a proxy for type `T`
 			let pointer = UnsafeMutablePointer<T>.alloc(0)

--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -59,10 +59,11 @@ public final class Mapper<N: Mappable> {
 	
 	/// Maps a JSON dictionary to an existing object that conforms to Mappable.
 	/// Usefull for those pesky objects that have crappy designated initializers like NSManagedObject
-	public func map(JSONDictionary: [String : AnyObject], var toObject object: N) -> N {
+	public func map(JSONDictionary: [String : AnyObject], toObject object: N) -> N {
+		var mutableObject = object
 		let map = Map(mappingType: .FromJSON, JSONDictionary: JSONDictionary, toObject: true)
-		object.mapping(map)
-		return object
+		mutableObject.mapping(map)
+		return mutableObject
 	}
 
 	//MARK: Mapping functions that create an object
@@ -198,16 +199,17 @@ public final class Mapper<N: Mappable> {
 	}
 	
     /// Maps a JSON dictionary of dictionaries to an existing dictionary of Mappble objects
-    public func mapDictionary(JSONDictionary: [String : [String : AnyObject]], var toDictionary dictionary: [String : N]) -> [String : N] {
+    public func mapDictionary(JSONDictionary: [String : [String : AnyObject]], toDictionary dictionary: [String : N]) -> [String : N] {
+		var mutableDictionary = dictionary
         for (key, value) in JSONDictionary {
             if let object = dictionary[key] {
                 Mapper().map(value, toObject: object)
             } else {
-                dictionary[key] = Mapper().map(value)
+                mutableDictionary[key] = Mapper().map(value)
             }
         }
         
-        return dictionary
+        return mutableDictionary
     }
 	
 	/// Maps a JSON object to a dictionary of arrays of Mappable objects
@@ -291,9 +293,10 @@ extension Mapper {
 	// MARK: Functions that create JSON from objects	
 	
 	///Maps an object that conforms to Mappable to a JSON dictionary <String : AnyObject>
-	public func toJSON(var object: N) -> [String : AnyObject] {
+	public func toJSON( object: N) -> [String : AnyObject] {
+		var mutableObject = object
 		let map = Map(mappingType: .ToJSON, JSONDictionary: [:])
-		object.mapping(map)
+		mutableObject.mapping(map)
 		return map.JSONDictionary
 	}
 	

--- a/ObjectMapper/Transforms/TransformType.swift
+++ b/ObjectMapper/Transforms/TransformType.swift
@@ -27,8 +27,8 @@
 //  THE SOFTWARE.
 
 public protocol TransformType {
-	typealias Object
-	typealias JSON
+	associatedtype Object
+	associatedtype JSON
 
 	func transformFromJSON(value: AnyObject?) -> Object?
 	func transformToJSON(value: Object?) -> JSON?


### PR DESCRIPTION
`++` / `--`, `var` Paramter and `typealias`in Protocols are marked as deprecated and will result in an compiler error in Swift 3.

[remove-pre-post-inc-decrement](https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md)
[remove-var-parameters](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-parameters.md)
[replace-typealias-associated](https://github.com/apple/swift-evolution/blob/master/proposals/0011-replace-typealias-associated.md)