### PR TITLE
Swift 3.0 support

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -561,7 +561,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = hearst;
 				TargetAttributes = {
 					6A05B7A51BE274BE00F19B53 = {
@@ -575,9 +575,11 @@
 					};
 					6AAC8F7519F03C2900E7A677 = {
 						CreatedOnToolsVersion = 6.0.1;
+						LastSwiftMigration = 0800;
 					};
 					6AAC8F8019F03C2900E7A677 = {
 						CreatedOnToolsVersion = 6.0.1;
+						LastSwiftMigration = 0800;
 					};
 					CD1602FE1AC023D5000CD69A = {
 						CreatedOnToolsVersion = 6.2;
@@ -997,6 +999,7 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -1044,6 +1047,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -1077,6 +1081,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.hearst.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -1097,6 +1102,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.hearst.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -1114,6 +1120,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heart.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1125,6 +1132,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heart.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/ObjectMapper.xcodeproj/xcshareddata/xcschemes/ObjectMapper-Mac.xcscheme
+++ b/ObjectMapper.xcodeproj/xcshareddata/xcschemes/ObjectMapper-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Release">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -66,11 +66,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -88,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/ObjectMapper.xcodeproj/xcshareddata/xcschemes/ObjectMapper-iOS.xcscheme
+++ b/ObjectMapper.xcodeproj/xcshareddata/xcschemes/ObjectMapper-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ObjectMapper.xcodeproj/xcshareddata/xcschemes/ObjectMapper-tvOS.xcscheme
+++ b/ObjectMapper.xcodeproj/xcshareddata/xcschemes/ObjectMapper-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ObjectMapper.xcodeproj/xcshareddata/xcschemes/ObjectMapper-watchOS.xcscheme
+++ b/ObjectMapper.xcodeproj/xcshareddata/xcschemes/ObjectMapper-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -29,58 +29,58 @@
 internal final class FromJSON {
 	
 	/// Basic type
-	class func basicType<FieldType>(inout field: FieldType, object: FieldType?) {
+	class func basicType<FieldType>(_ field: inout FieldType, object: FieldType?) {
 		if let value = object {
 			field = value
 		}
 	}
 	
 	/// optional basic type
-	class func optionalBasicType<FieldType>(inout field: FieldType?, object: FieldType?) {
+	class func optionalBasicType<FieldType>(_ field: inout FieldType?, object: FieldType?) {
 		field = object
 	}
 	
 	/// Implicitly unwrapped optional basic type
-	class func optionalBasicType<FieldType>(inout field: FieldType!, object: FieldType?) {
+	class func optionalBasicType<FieldType>(_ field: inout FieldType!, object: FieldType?) {
 		field = object
 	}
 	
 	/// Mappable object
-	class func object<N: Mappable>(inout field: N, map: Map) {
+	class func object<N: Mappable>(_ field: inout N, map: Map) {
 		if map.toObject {
-			Mapper(context: map.context).map(map.currentValue, toObject: field)
+			_ = Mapper(context: map.context).map(map.currentValue, toObject: field)
 		} else if let value: N = Mapper(context: map.context).map(map.currentValue) {
 			field = value
 		}
 	}
 	
 	/// Optional Mappable Object
-	class func optionalObject<N: Mappable>(inout field: N?, map: Map) {
+	class func optionalObject<N: Mappable>(_ field: inout N?, map: Map) {
 		if let field = field where map.toObject && map.currentValue != nil {
-			Mapper(context: map.context).map(map.currentValue, toObject: field)
+			_ = Mapper(context: map.context).map(map.currentValue, toObject: field)
 		} else {
 			field = Mapper(context: map.context).map(map.currentValue)
 		}
 	}
 	
 	/// Implicitly unwrapped Optional Mappable Object
-	class func optionalObject<N: Mappable>(inout field: N!, map: Map) {
+	class func optionalObject<N: Mappable>(_ field: inout N!, map: Map) {
 		if let field = field where map.toObject && map.currentValue != nil {
-			Mapper(context: map.context).map(map.currentValue, toObject: field)
+			_ = Mapper(context: map.context).map(map.currentValue, toObject: field)
 		} else {
 			field = Mapper(context: map.context).map(map.currentValue)
 		}
 	}
 	
 	/// mappable object array
-	class func objectArray<N: Mappable>(inout field: Array<N>, map: Map) {
+	class func objectArray<N: Mappable>(_ field: inout Array<N>, map: Map) {
 		if let objects = Mapper<N>(context: map.context).mapArray(map.currentValue) {
 			field = objects
 		}
 	}
 	
 	/// optional mappable object array
-	class func optionalObjectArray<N: Mappable>(inout field: Array<N>?, map: Map) {
+	class func optionalObjectArray<N: Mappable>(_ field: inout Array<N>?, map: Map) {
 		if let objects: Array<N> = Mapper(context: map.context).mapArray(map.currentValue) {
 			field = objects
 		} else {
@@ -89,7 +89,7 @@ internal final class FromJSON {
 	}
 	
 	/// Implicitly unwrapped optional mappable object array
-	class func optionalObjectArray<N: Mappable>(inout field: Array<N>!, map: Map) {
+	class func optionalObjectArray<N: Mappable>(_ field: inout Array<N>!, map: Map) {
 		if let objects: Array<N> = Mapper(context: map.context).mapArray(map.currentValue) {
 			field = objects
 		} else {
@@ -98,26 +98,26 @@ internal final class FromJSON {
 	}
 	
 	/// mappable object array
-	class func twoDimensionalObjectArray<N: Mappable>(inout field: Array<Array<N>>, map: Map) {
+	class func twoDimensionalObjectArray<N: Mappable>(_ field: inout Array<Array<N>>, map: Map) {
 		if let objects = Mapper<N>(context: map.context).mapArrayOfArrays(map.currentValue) {
 			field = objects
 		}
 	}
 	
 	/// optional mappable 2 dimentional object array
-	class func optionalTwoDimensionalObjectArray<N: Mappable>(inout field: Array<Array<N>>?, map: Map) {
+	class func optionalTwoDimensionalObjectArray<N: Mappable>(_ field: inout Array<Array<N>>?, map: Map) {
 		field = Mapper(context: map.context).mapArrayOfArrays(map.currentValue)
 	}
 	
 	/// Implicitly unwrapped optional 2 dimentional mappable object array
-	class func optionalTwoDimensionalObjectArray<N: Mappable>(inout field: Array<Array<N>>!, map: Map) {
+	class func optionalTwoDimensionalObjectArray<N: Mappable>(_ field: inout Array<Array<N>>!, map: Map) {
 		field = Mapper(context: map.context).mapArrayOfArrays(map.currentValue)
 	}
 	
 	/// Dctionary containing Mappable objects
-	class func objectDictionary<N: Mappable>(inout field: Dictionary<String, N>, map: Map) {
+	class func objectDictionary<N: Mappable>(_ field: inout Dictionary<String, N>, map: Map) {
 		if map.toObject {
-			Mapper<N>(context: map.context).mapDictionary(map.currentValue, toDictionary: field)
+			_ = Mapper<N>(context: map.context).mapDictionary(map.currentValue, toDictionary: field)
 		} else {
 			if let objects = Mapper<N>(context: map.context).mapDictionary(map.currentValue) {
 				field = objects
@@ -126,54 +126,54 @@ internal final class FromJSON {
 	}
 	
 	/// Optional dictionary containing Mappable objects
-	class func optionalObjectDictionary<N: Mappable>(inout field: Dictionary<String, N>?, map: Map) {
+	class func optionalObjectDictionary<N: Mappable>(_ field: inout Dictionary<String, N>?, map: Map) {
 		if let field = field where map.toObject && map.currentValue != nil {
-			Mapper(context: map.context).mapDictionary(map.currentValue, toDictionary: field)
+			_ = Mapper(context: map.context).mapDictionary(map.currentValue, toDictionary: field)
 		} else {
 			field = Mapper(context: map.context).mapDictionary(map.currentValue)
 		}
 	}
 	
 	/// Implicitly unwrapped Dictionary containing Mappable objects
-	class func optionalObjectDictionary<N: Mappable>(inout field: Dictionary<String, N>!, map: Map) {
+	class func optionalObjectDictionary<N: Mappable>(_ field: inout Dictionary<String, N>!, map: Map) {
 		if let field = field where map.toObject && map.currentValue != nil {
-			Mapper(context: map.context).mapDictionary(map.currentValue, toDictionary: field)
+			_ = Mapper(context: map.context).mapDictionary(map.currentValue, toDictionary: field)
 		} else {
 			field = Mapper(context: map.context).mapDictionary(map.currentValue)
 		}
 	}
 	
 	/// Dictionary containing Array of Mappable objects
-	class func objectDictionaryOfArrays<N: Mappable>(inout field: Dictionary<String, [N]>, map: Map) {
+	class func objectDictionaryOfArrays<N: Mappable>(_ field: inout Dictionary<String, [N]>, map: Map) {
 		if let objects = Mapper<N>(context: map.context).mapDictionaryOfArrays(map.currentValue) {
 			field = objects
 		}
 	}
 	
 	/// Optional Dictionary containing Array of Mappable objects
-	class func optionalObjectDictionaryOfArrays<N: Mappable>(inout field: Dictionary<String, [N]>?, map: Map) {
+	class func optionalObjectDictionaryOfArrays<N: Mappable>(_ field: inout Dictionary<String, [N]>?, map: Map) {
 		field = Mapper<N>(context: map.context).mapDictionaryOfArrays(map.currentValue)
 	}
 	
 	/// Implicitly unwrapped Dictionary containing Array of Mappable objects
-	class func optionalObjectDictionaryOfArrays<N: Mappable>(inout field: Dictionary<String, [N]>!, map: Map) {
+	class func optionalObjectDictionaryOfArrays<N: Mappable>(_ field: inout Dictionary<String, [N]>!, map: Map) {
 		field = Mapper<N>(context: map.context).mapDictionaryOfArrays(map.currentValue)
 	}
 	
 	/// mappable object Set
-	class func objectSet<N: Mappable>(inout field: Set<N>, map: Map) {
+	class func objectSet<N: Mappable>(_ field: inout Set<N>, map: Map) {
 		if let objects = Mapper<N>(context: map.context).mapSet(map.currentValue) {
 			field = objects
 		}
 	}
 	
 	/// optional mappable object array
-	class func optionalObjectSet<N: Mappable>(inout field: Set<N>?, map: Map) {
+	class func optionalObjectSet<N: Mappable>(_ field: inout Set<N>?, map: Map) {
 		field = Mapper(context: map.context).mapSet(map.currentValue)
 	}
 	
 	/// Implicitly unwrapped optional mappable object array
-	class func optionalObjectSet<N: Mappable>(inout field: Set<N>!, map: Map) {
+	class func optionalObjectSet<N: Mappable>(_ field: inout Set<N>!, map: Map) {
 		field = Mapper(context: map.context).mapSet(map.currentValue)
 	}
 	

--- a/ObjectMapper/Core/Map.swift
+++ b/ObjectMapper/Core/Map.swift
@@ -61,7 +61,7 @@ public final class Map {
 	/// The Key paramater can be a period separated string (ex. "distance.value") to access sub objects.
 	public subscript(key: String) -> Map {
 		// save key and value associated to it
-		let nested = key.containsString(".")
+		let nested = key.contains(".")
         return self[key, nested: nested, ignoreNil: false]
 	}
 	
@@ -70,7 +70,7 @@ public final class Map {
 	}
 	
     public subscript(key: String, ignoreNil ignoreNil: Bool) -> Map {
-        let nested = key.containsString(".")
+        let nested = key.contains(".")
         return self[key, nested: nested, ignoreNil: ignoreNil]
     }
     
@@ -88,7 +88,7 @@ public final class Map {
 			currentValue = isNSNull ? nil : object
 		} else {
 			// break down the components of the key that are separated by .
-			(isKeyPresent, currentValue) = valueFor(ArraySlice(key.componentsSeparatedByString(".")), dictionary: JSONDictionary)
+			(isKeyPresent, currentValue) = valueFor(ArraySlice(key.components(separatedBy: ".")), dictionary: JSONDictionary)
 		}
 		
 		// update isKeyPresent if ignoreNil is true
@@ -105,7 +105,7 @@ public final class Map {
 		return currentValue as? T
 	}
 	
-	public func valueOr<T>(@autoclosure defaultValue: () -> T) -> T {
+	public func valueOr<T>( _ defaultValue: @autoclosure() -> T) -> T {
 		return value() ?? defaultValue()
 	}
 	
@@ -119,9 +119,9 @@ public final class Map {
 			failedCount += 1
 			
 			// Returns dummy memory as a proxy for type `T`
-			let pointer = UnsafeMutablePointer<T>.alloc(0)
-			pointer.dealloc(0)
-			return pointer.memory
+			let pointer = UnsafeMutablePointer<T>(allocatingCapacity: 0)
+			pointer.deallocateCapacity(0)
+			return pointer.pointee
 		}
 	}
 	
@@ -132,7 +132,7 @@ public final class Map {
 }
 
 /// Fetch value from JSON dictionary, loop through keyPathComponents until we reach the desired object
-private func valueFor(keyPathComponents: ArraySlice<String>, dictionary: [String: AnyObject]) -> (Bool, AnyObject?) {
+private func valueFor(_ keyPathComponents: ArraySlice<String>, dictionary: [String: AnyObject]) -> (Bool, AnyObject?) {
 	// Implement it as a tail recursive function.
 	if keyPathComponents.isEmpty {
 		return (false, nil)
@@ -157,7 +157,7 @@ private func valueFor(keyPathComponents: ArraySlice<String>, dictionary: [String
 }
 
 /// Fetch value from JSON Array, loop through keyPathComponents them until we reach the desired object
-private func valueFor(keyPathComponents: ArraySlice<String>, array: [AnyObject]) -> (Bool, AnyObject?) {
+private func valueFor(_ keyPathComponents: ArraySlice<String>, array: [AnyObject]) -> (Bool, AnyObject?) {
 	// Implement it as a tail recursive function.
 	
 	if keyPathComponents.isEmpty {

--- a/ObjectMapper/Core/Mappable.swift
+++ b/ObjectMapper/Core/Mappable.swift
@@ -12,16 +12,16 @@ public protocol Mappable {
 	/// This function can be used to validate JSON prior to mapping. Return nil to cancel mapping at this point
 	init?(_ map: Map)
 	/// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
-	mutating func mapping(map: Map)
+	mutating func mapping(_ map: Map)
 	/// This is an optional function that can be used to:
 	///		1) provide an existing cached object to be used for mapping
 	///		2) return an object of another class (which conforms to Mappable) to be used for mapping. For instance, you may inspect the JSON to infer the type of object that should be used for any given mapping
-	static func objectForMapping(map: Map) -> Mappable?
+	static func objectForMapping(_ map: Map) -> Mappable?
 }
 
 public extension Mappable {
 	
-	public static func objectForMapping(map: Map) -> Mappable? {
+	public static func objectForMapping(_ map: Map) -> Mappable? {
 		return nil
 	}
 	
@@ -49,7 +49,7 @@ public extension Mappable {
 	}
 	
 	/// Returns the JSON String for the object
-	public func toJSONString(prettyPrint: Bool = false) -> String? {
+	public func toJSONString(_ prettyPrint: Bool = false) -> String? {
 		return Mapper().toJSONString(self, prettyPrint: prettyPrint)
 	}
 }
@@ -80,7 +80,7 @@ public extension Array where Element: Mappable {
 	}
 	
 	/// Returns the JSON String for the object
-	public func toJSONString(prettyPrint: Bool = false) -> String? {
+	public func toJSONString(_ prettyPrint: Bool = false) -> String? {
 		return Mapper().toJSONString(self, prettyPrint: prettyPrint)
 	}
 }
@@ -111,7 +111,7 @@ public extension Set where Element: Mappable {
 	}
 	
 	/// Returns the JSON String for the object
-	public func toJSONString(prettyPrint: Bool = false) -> String? {
+	public func toJSONString(_ prettyPrint: Bool = false) -> String? {
 		return Mapper().toJSONString(self, prettyPrint: prettyPrint)
 	}
 }

--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -29,8 +29,8 @@
 import Foundation
 
 public enum MappingType {
-	case FromJSON
-	case ToJSON
+	case fromJSON
+	case tojson
 }
 
 /// The Mapper class provides methods for converting Model objects to JSON and methods for converting JSON to Model objects
@@ -45,7 +45,7 @@ public final class Mapper<N: Mappable> {
 	// MARK: Mapping functions that map to an existing object toObject
 	
 	/// Maps a JSON object to an existing Mappable object if it is a JSON dictionary, or returns the passed object as is
-	public func map(JSON: AnyObject?, toObject object: N) -> N {
+	public func map(_ JSON: AnyObject?, toObject object: N) -> N {
 		if let JSON = JSON as? [String : AnyObject] {
 			return map(JSON, toObject: object)
 		}
@@ -54,7 +54,7 @@ public final class Mapper<N: Mappable> {
 	}
 	
 	/// Map a JSON string onto an existing object
-	public func map(JSONString: String, toObject object: N) -> N {
+	public func map(_ JSONString: String, toObject object: N) -> N {
 		if let JSON = Mapper.parseJSONDictionary(JSONString) {
 			return map(JSON, toObject: object)
 		}
@@ -63,9 +63,9 @@ public final class Mapper<N: Mappable> {
 	
 	/// Maps a JSON dictionary to an existing object that conforms to Mappable.
 	/// Usefull for those pesky objects that have crappy designated initializers like NSManagedObject
-	public func map(JSONDictionary: [String : AnyObject], toObject object: N) -> N {
+	public func map(_ JSONDictionary: [String : AnyObject], toObject object: N) -> N {
 		var mutableObject = object
-		let map = Map(mappingType: .FromJSON, JSONDictionary: JSONDictionary, toObject: true, context: context)
+		let map = Map(mappingType: .fromJSON, JSONDictionary: JSONDictionary, toObject: true, context: context)
 		mutableObject.mapping(map)
 		return mutableObject
 	}
@@ -73,7 +73,7 @@ public final class Mapper<N: Mappable> {
 	//MARK: Mapping functions that create an object
 	
 	/// Map an optional JSON string to an object that conforms to Mappable
-	public func map(JSONString: String?) -> N? {
+	public func map(_ JSONString: String?) -> N? {
 		if let JSONString = JSONString {
 			return map(JSONString)
 		}
@@ -82,7 +82,7 @@ public final class Mapper<N: Mappable> {
 	}
 	
 	/// Map a JSON string to an object that conforms to Mappable
-	public func map(JSONString: String) -> N? {
+	public func map(_ JSONString: String) -> N? {
 		if let JSON = Mapper.parseJSONDictionary(JSONString) {
 			return map(JSON)
 		}
@@ -91,12 +91,12 @@ public final class Mapper<N: Mappable> {
 	}
 	
 	/// Map a JSON NSString to an object that conforms to Mappable
-	public func map(JSONString: NSString) -> N? {
+	public func map(_ JSONString: NSString) -> N? {
 		return map(JSONString as String)
 	}
 	
 	/// Maps a JSON object to a Mappable object if it is a JSON dictionary or NSString, or returns nil.
-	public func map(JSON: AnyObject?) -> N? {
+	public func map(_ JSON: AnyObject?) -> N? {
 		if let JSON = JSON as? [String : AnyObject] {
 			return map(JSON)
 		}
@@ -105,8 +105,8 @@ public final class Mapper<N: Mappable> {
 	}
 
 	/// Maps a JSON dictionary to an object that conforms to Mappable
-	public func map(JSONDictionary: [String : AnyObject]) -> N? {
-		let map = Map(mappingType: .FromJSON, JSONDictionary: JSONDictionary, context: context)
+	public func map(_ JSONDictionary: [String : AnyObject]) -> N? {
+		let map = Map(mappingType: .fromJSON, JSONDictionary: JSONDictionary, context: context)
 		
 		// check if objectForMapping returns an object for mapping
 		if var object = N.self.objectForMapping(map) as? N {
@@ -126,7 +126,7 @@ public final class Mapper<N: Mappable> {
 	// MARK: Mapping functions for Arrays and Dictionaries
 	
 	/// Maps a JSON array to an object that conforms to Mappable
-	public func mapArray(JSONString: String) -> [N]? {
+	public func mapArray(_ JSONString: String) -> [N]? {
 		let parsedJSON: AnyObject? = Mapper.parseJSONString(JSONString)
 
 		if let objectArray = mapArray(parsedJSON) {
@@ -143,7 +143,7 @@ public final class Mapper<N: Mappable> {
 	}
 	
 	/// Maps a optional JSON String into an array of objects that conforms to Mappable
-	public func mapArray(JSONString: String?) -> [N]? {
+	public func mapArray(_ JSONString: String?) -> [N]? {
 		if let JSONString = JSONString {
 			return mapArray(JSONString)
 		}
@@ -152,7 +152,7 @@ public final class Mapper<N: Mappable> {
 	}
 	
 	/// Maps a JSON object to an array of Mappable objects if it is an array of JSON dictionary, or returns nil.
-	public func mapArray(JSON: AnyObject?) -> [N]? {
+	public func mapArray(_ JSON: AnyObject?) -> [N]? {
 		if let JSONArray = JSON as? [[String : AnyObject]] {
 			return mapArray(JSONArray)
 		}
@@ -161,20 +161,20 @@ public final class Mapper<N: Mappable> {
 	}
 	
 	/// Maps an array of JSON dictionary to an array of Mappable objects
-	public func mapArray(JSONArray: [[String : AnyObject]]) -> [N]? {
+	public func mapArray(_ JSONArray: [[String : AnyObject]]) -> [N]? {
 		// map every element in JSON array to type N
 		let result = JSONArray.flatMap(map)
 		return result
 	}
 	
 	/// Maps a JSON object to a dictionary of Mappable objects if it is a JSON dictionary of dictionaries, or returns nil.
-	public func mapDictionary(JSONString: String) -> [String : N]? {
+	public func mapDictionary(_ JSONString: String) -> [String : N]? {
 		let parsedJSON: AnyObject? = Mapper.parseJSONString(JSONString)
 		return mapDictionary(parsedJSON)
 	}
 	
 	/// Maps a JSON object to a dictionary of Mappable objects if it is a JSON dictionary of dictionaries, or returns nil.
-	public func mapDictionary(JSON: AnyObject?) -> [String : N]? {
+	public func mapDictionary(_ JSON: AnyObject?) -> [String : N]? {
 		if let JSONDictionary = JSON as? [String : [String : AnyObject]] {
 			return mapDictionary(JSONDictionary)
 		}
@@ -183,7 +183,7 @@ public final class Mapper<N: Mappable> {
 	}
 
 	/// Maps a JSON dictionary of dictionaries to a dictionary of Mappble objects
-	public func mapDictionary(JSONDictionary: [String : [String : AnyObject]]) -> [String : N]? {
+	public func mapDictionary(_ JSONDictionary: [String : [String : AnyObject]]) -> [String : N]? {
 		// map every value in dictionary to type N
 		let result = JSONDictionary.filterMap(map)
 		if result.isEmpty == false {
@@ -194,7 +194,7 @@ public final class Mapper<N: Mappable> {
 	}
 	
 	/// Maps a JSON object to a dictionary of Mappable objects if it is a JSON dictionary of dictionaries, or returns nil.
-	public func mapDictionary(JSON: AnyObject?, toDictionary dictionary: [String : N]) -> [String : N] {
+	public func mapDictionary(_ JSON: AnyObject?, toDictionary dictionary: [String : N]) -> [String : N] {
 		if let JSONDictionary = JSON as? [String : [String : AnyObject]] {
 			return mapDictionary(JSONDictionary, toDictionary: dictionary)
 		}
@@ -203,11 +203,11 @@ public final class Mapper<N: Mappable> {
 	}
 	
     /// Maps a JSON dictionary of dictionaries to an existing dictionary of Mappble objects
-    public func mapDictionary(JSONDictionary: [String : [String : AnyObject]], toDictionary dictionary: [String : N]) -> [String : N] {
+    public func mapDictionary(_ JSONDictionary: [String : [String : AnyObject]], toDictionary dictionary: [String : N]) -> [String : N] {
 		var mutableDictionary = dictionary
         for (key, value) in JSONDictionary {
             if let object = dictionary[key] {
-				map(value, toObject: object)
+				_ = map(value, toObject: object)
             } else {
 				mutableDictionary[key] = map(value)
             }
@@ -217,7 +217,7 @@ public final class Mapper<N: Mappable> {
     }
 	
 	/// Maps a JSON object to a dictionary of arrays of Mappable objects
-	public func mapDictionaryOfArrays(JSON: AnyObject?) -> [String : [N]]? {
+	public func mapDictionaryOfArrays(_ JSON: AnyObject?) -> [String : [N]]? {
 		if let JSONDictionary = JSON as? [String : [[String : AnyObject]]] {
 			return mapDictionaryOfArrays(JSONDictionary)
 		}
@@ -226,7 +226,7 @@ public final class Mapper<N: Mappable> {
 	}
 	
 	///Maps a JSON dictionary of arrays to a dictionary of arrays of Mappable objects
-	public func mapDictionaryOfArrays(JSONDictionary: [String : [[String : AnyObject]]]) -> [String : [N]]? {
+	public func mapDictionaryOfArrays(_ JSONDictionary: [String : [[String : AnyObject]]]) -> [String : [N]]? {
 		// map every value in dictionary to type N
 		let result = JSONDictionary.filterMap {
             mapArray($0)
@@ -240,7 +240,7 @@ public final class Mapper<N: Mappable> {
 	}
 	
 	/// Maps an 2 dimentional array of JSON dictionaries to a 2 dimentional array of Mappable objects
-	public func mapArrayOfArrays(JSON: AnyObject?) -> [[N]]? {
+	public func mapArrayOfArrays(_ JSON: AnyObject?) -> [[N]]? {
 		if let JSONArray = JSON as? [[[String : AnyObject]]] {
 			var objectArray = [[N]]()
 			for innerJSONArray in JSONArray {
@@ -260,13 +260,13 @@ public final class Mapper<N: Mappable> {
 	// MARK: Utility functions for converting strings to JSON objects
 	
 	/// Convert a JSON String into a Dictionary<String, AnyObject> using NSJSONSerialization
-	public static func parseJSONDictionary(JSON: String) -> [String : AnyObject]? {
+	public static func parseJSONDictionary(_ JSON: String) -> [String : AnyObject]? {
 		let parsedJSON: AnyObject? = Mapper.parseJSONString(JSON)
 		return Mapper.parseJSONDictionary(parsedJSON)
 	}
 	
 	/// Convert a JSON Object into a Dictionary<String, AnyObject> using NSJSONSerialization
-	public static func parseJSONDictionary(JSON: AnyObject?) -> [String : AnyObject]? {
+	public static func parseJSONDictionary(_ JSON: AnyObject?) -> [String : AnyObject]? {
 		if let JSONDict = JSON as? [String : AnyObject] {
 			return JSONDict
 		}
@@ -275,12 +275,12 @@ public final class Mapper<N: Mappable> {
 	}
 
 	/// Convert a JSON String into an Object using NSJSONSerialization
-	public static func parseJSONString(JSON: String) -> AnyObject? {
-		let data = JSON.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
+	public static func parseJSONString(_ JSON: String) -> AnyObject? {
+		let data = JSON.data(using: String.Encoding.utf8, allowLossyConversion: true)
 		if let data = data {
 			let parsedJSON: AnyObject?
 			do {
-				parsedJSON = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.AllowFragments)
+				parsedJSON = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
 			} catch let error {
 				print(error)
 				parsedJSON = nil
@@ -297,15 +297,15 @@ extension Mapper {
 	// MARK: Functions that create JSON from objects	
 	
 	///Maps an object that conforms to Mappable to a JSON dictionary <String : AnyObject>
-	public func toJSON(object: N) -> [String : AnyObject] {
+	public func toJSON(_ object: N) -> [String : AnyObject] {
 		var mutableObject = object
-		let map = Map(mappingType: .ToJSON, JSONDictionary: [:], context: context)
+		let map = Map(mappingType: .tojson, JSONDictionary: [:], context: context)
 		mutableObject.mapping(map)
 		return map.JSONDictionary
 	}
 	
 	///Maps an array of Objects to an array of JSON dictionaries [[String : AnyObject]]
-	public func toJSONArray(array: [N]) -> [[String : AnyObject]] {
+	public func toJSONArray(_ array: [N]) -> [[String : AnyObject]] {
 		return array.map {
 			// convert every element in array to JSON dictionary equivalent
 			self.toJSON($0)
@@ -313,7 +313,7 @@ extension Mapper {
 	}
 	
 	///Maps a dictionary of Objects that conform to Mappable to a JSON dictionary of dictionaries.
-	public func toJSONDictionary(dictionary: [String : N]) -> [String : [String : AnyObject]] {
+	public func toJSONDictionary(_ dictionary: [String : N]) -> [String : [String : AnyObject]] {
 		return dictionary.map { k, v in
 			// convert every value in dictionary to its JSON dictionary equivalent
 			return (k, self.toJSON(v))
@@ -321,7 +321,7 @@ extension Mapper {
 	}
 	
 	///Maps a dictionary of Objects that conform to Mappable to a JSON dictionary of dictionaries.
-	public func toJSONDictionaryOfArrays(dictionary: [String : [N]]) -> [String : [[String : AnyObject]]] {
+	public func toJSONDictionaryOfArrays(_ dictionary: [String : [N]]) -> [String : [[String : AnyObject]]] {
 		return dictionary.map { k, v in
 			// convert every value (array) in dictionary to its JSON dictionary equivalent
 			return (k, self.toJSONArray(v))
@@ -329,35 +329,35 @@ extension Mapper {
 	}
 	
 	/// Maps an Object to a JSON string with option of pretty formatting
-	public func toJSONString(object: N, prettyPrint: Bool = false) -> String? {
+	public func toJSONString(_ object: N, prettyPrint: Bool = false) -> String? {
 		let JSONDict = toJSON(object)
 		
         return Mapper.toJSONString(JSONDict, prettyPrint: prettyPrint)
 	}
 
     /// Maps an array of Objects to a JSON string with option of pretty formatting	
-    public func toJSONString(array: [N], prettyPrint: Bool = false) -> String? {
+    public func toJSONString(_ array: [N], prettyPrint: Bool = false) -> String? {
         let JSONDict = toJSONArray(array)
         
         return Mapper.toJSONString(JSONDict, prettyPrint: prettyPrint)
     }
 	
 	/// Converts an Object to a JSON string with option of pretty formatting
-	public static func toJSONString(JSONObject: AnyObject, prettyPrint: Bool) -> String? {
-		let options: NSJSONWritingOptions = prettyPrint ? .PrettyPrinted : []
+	public static func toJSONString(_ JSONObject: AnyObject, prettyPrint: Bool) -> String? {
+		let options: JSONSerialization.WritingOptions = prettyPrint ? .prettyPrinted : []
 		if let JSON = Mapper.toJSONData(JSONObject, options: options) {
-			return String(data: JSON, encoding: NSUTF8StringEncoding)
+			return String(data: JSON, encoding: String.Encoding.utf8)
 		}
 		
 		return nil
 	}
 	
 	/// Converts an Object to JSON data with options
-	public static func toJSONData(JSONObject: AnyObject, options: NSJSONWritingOptions) -> NSData? {
-		if NSJSONSerialization.isValidJSONObject(JSONObject) {
-			let JSONData: NSData?
+	public static func toJSONData(_ JSONObject: AnyObject, options: JSONSerialization.WritingOptions) -> Data? {
+		if JSONSerialization.isValidJSONObject(JSONObject) {
+			let JSONData: Data?
 			do {
-				JSONData = try NSJSONSerialization.dataWithJSONObject(JSONObject, options: options)
+				JSONData = try JSONSerialization.data(withJSONObject: JSONObject, options: options)
 			} catch let error {
 				print(error)
 				JSONData = nil
@@ -373,7 +373,7 @@ extension Mapper {
 extension Mapper where N: Hashable {
 	
 	/// Maps a JSON array to an object that conforms to Mappable
-	public func mapSet(JSONString: String) -> Set<N>? {
+	public func mapSet(_ JSONString: String) -> Set<N>? {
 		let parsedJSON: AnyObject? = Mapper.parseJSONString(JSONString)
 		
 		if let objectArray = mapArray(parsedJSON) {
@@ -390,7 +390,7 @@ extension Mapper where N: Hashable {
 	}
 	
 	/// Maps a JSON object to an Set of Mappable objects if it is an array of JSON dictionary, or returns nil.
-	public func mapSet(JSON: AnyObject?) -> Set<N>? {
+	public func mapSet(_ JSON: AnyObject?) -> Set<N>? {
 		if let JSONArray = JSON as? [[String : AnyObject]] {
 			return mapSet(JSONArray)
 		}
@@ -399,13 +399,13 @@ extension Mapper where N: Hashable {
 	}
 	
 	/// Maps an Set of JSON dictionary to an array of Mappable objects
-	public func mapSet(JSONArray: [[String : AnyObject]]) -> Set<N> {
+	public func mapSet(_ JSONArray: [[String : AnyObject]]) -> Set<N> {
 		// map every element in JSON array to type N
 		return Set(JSONArray.flatMap(map))
 	}
 
 	///Maps a Set of Objects to a Set of JSON dictionaries [[String : AnyObject]]
-	public func toJSONSet(set: Set<N>) -> [[String : AnyObject]] {
+	public func toJSONSet(_ set: Set<N>) -> [[String : AnyObject]] {
 		return set.map {
 			// convert every element in set to JSON dictionary equivalent
 			self.toJSON($0)
@@ -413,7 +413,7 @@ extension Mapper where N: Hashable {
 	}
 	
 	/// Maps a set of Objects to a JSON string with option of pretty formatting
-	public func toJSONString(set: Set<N>, prettyPrint: Bool = false) -> String? {
+	public func toJSONString(_ set: Set<N>, prettyPrint: Bool = false) -> String? {
 		let JSONDict = toJSONSet(set)
 		
 		return Mapper.toJSONString(JSONDict, prettyPrint: prettyPrint)
@@ -421,7 +421,7 @@ extension Mapper where N: Hashable {
 }
 
 extension Dictionary {
-	internal func map<K: Hashable, V>(@noescape f: Element -> (K, V)) -> [K : V] {
+	internal func map<K: Hashable, V>( _ f: @noescape(Element) -> (K, V)) -> [K : V] {
 		var mapped = [K : V]()
 
 		for element in self {
@@ -432,7 +432,7 @@ extension Dictionary {
 		return mapped
 	}
 
-	internal func map<K: Hashable, V>(@noescape f: Element -> (K, [V])) -> [K : [V]] {
+	internal func map<K: Hashable, V>( _ f: @noescape(Element) -> (K, [V])) -> [K : [V]] {
 		var mapped = [K : [V]]()
 		
 		for element in self {
@@ -444,7 +444,7 @@ extension Dictionary {
 	}
 
 	
-	internal func filterMap<U>(@noescape f: Value -> U?) -> [Key : U] {
+	internal func filterMap<U>(@noescape _ f: @noescape(Value) -> U?) -> [Key : U] {
 		var mapped = [Key : U]()
 
 		for (key, value) in self {

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -37,33 +37,33 @@ infix operator <- {}
 // MARK:- Objects with Basic types
 
 /// Object of Basic type
-public func <- <T>(inout left: T, right: Map) {
+public func <- <T>(left: inout T, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.basicType(&left, object: right.value())
-	case .ToJSON:
+	case .tojson:
 		ToJSON.basicType(left, map: right)
 	default: ()
 	}
 }
 
 /// Optional object of basic type
-public func <- <T>(inout left: T?, right: Map) {
+public func <- <T>(left: inout T?, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalBasicType(&left, object: right.value())
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalBasicType(left, map: right)
 	default: ()
 	}
 }
 
 /// Implicitly unwrapped optional object of basic type
-public func <- <T>(inout left: T!, right: Map) {
+public func <- <T>(left: inout T!, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalBasicType(&left, object: right.value())
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalBasicType(left, map: right)
 	default: ()
 	}
@@ -72,64 +72,64 @@ public func <- <T>(inout left: T!, right: Map) {
 // MARK:- Raw Representable types
 
 /// Object of Raw Representable type
-public func <- <T: RawRepresentable>(inout left: T, right: Map) {
+public func <- <T: RawRepresentable>(left: inout T, right: Map) {
 	left <- (right, EnumTransform())
 }
 
 /// Optional Object of Raw Representable type
-public func <- <T: RawRepresentable>(inout left: T?, right: Map) {
+public func <- <T: RawRepresentable>(left: inout T?, right: Map) {
 	left <- (right, EnumTransform())
 }
 
 /// Implicitly Unwrapped Optional Object of Raw Representable type
-public func <- <T: RawRepresentable>(inout left: T!, right: Map) {
+public func <- <T: RawRepresentable>(left: inout T!, right: Map) {
 	left <- (right, EnumTransform())
 }
 
 // MARK:- Arrays of Raw Representable type
 
 /// Array of Raw Representable object
-public func <- <T: RawRepresentable>(inout left: [T], right: Map) {
+public func <- <T: RawRepresentable>(left: inout [T], right: Map) {
 	left <- (right, EnumTransform())
 }
 
 /// Array of Raw Representable object
-public func <- <T: RawRepresentable>(inout left: [T]?, right: Map) {
+public func <- <T: RawRepresentable>(left: inout [T]?, right: Map) {
 	left <- (right, EnumTransform())
 }
 
 /// Array of Raw Representable object
-public func <- <T: RawRepresentable>(inout left: [T]!, right: Map) {
+public func <- <T: RawRepresentable>(left: inout [T]!, right: Map) {
 	left <- (right, EnumTransform())
 }
 
 // MARK:- Dictionaries of Raw Representable type
 
 /// Dictionary of Raw Representable object
-public func <- <T: RawRepresentable>(inout left: [String: T], right: Map) {
+public func <- <T: RawRepresentable>(left: inout [String: T], right: Map) {
 	left <- (right, EnumTransform())
 }
 
 /// Dictionary of Raw Representable object
-public func <- <T: RawRepresentable>(inout left: [String: T]?, right: Map) {
+public func <- <T: RawRepresentable>(left: inout [String: T]?, right: Map) {
 	left <- (right, EnumTransform())
 }
 
 /// Dictionary of Raw Representable object
-public func <- <T: RawRepresentable>(inout left: [String: T]!, right: Map) {
+public func <- <T: RawRepresentable>(left: inout [String: T]!, right: Map) {
 	left <- (right, EnumTransform())
 }
 
 // MARK:- Transforms
 
 /// Object of Basic type with Transform
-public func <- <Transform: TransformType>(inout left: Transform.Object, right: (Map, Transform)) {
+public func <- <Transform: TransformType>(left: inout Transform.Object, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let value = transform.transformFromJSON(map.currentValue)
 		FromJSON.basicType(&left, object: value)
-	case .ToJSON:
+	case .tojson:
 		let value: Transform.JSON? = transform.transformToJSON(left)
 		ToJSON.optionalBasicType(value, map: map)
 	default: ()
@@ -137,13 +137,13 @@ public func <- <Transform: TransformType>(inout left: Transform.Object, right: (
 }
 
 /// Optional object of basic type with Transform
-public func <- <Transform: TransformType>(inout left: Transform.Object?, right: (Map, Transform)) {
+public func <- <Transform: TransformType>(left: inout Transform.Object?, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let value = transform.transformFromJSON(map.currentValue)
 		FromJSON.optionalBasicType(&left, object: value)
-	case .ToJSON:
+	case .tojson:
 		let value: Transform.JSON? = transform.transformToJSON(left)
 		ToJSON.optionalBasicType(value, map: map)
 	default: ()
@@ -151,13 +151,13 @@ public func <- <Transform: TransformType>(inout left: Transform.Object?, right: 
 }
 
 /// Implicitly unwrapped optional object of basic type with Transform
-public func <- <Transform: TransformType>(inout left: Transform.Object!, right: (Map, Transform)) {
+public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let value = transform.transformFromJSON(map.currentValue)
 		FromJSON.optionalBasicType(&left, object: value)
-	case .ToJSON:
+	case .tojson:
 		let value: Transform.JSON? = transform.transformToJSON(left)
 		ToJSON.optionalBasicType(value, map: map)
 	default: ()
@@ -165,13 +165,13 @@ public func <- <Transform: TransformType>(inout left: Transform.Object!, right: 
 }
 
 /// Array of Basic type with Transform
-public func <- <Transform: TransformType>(inout left: [Transform.Object], right: (Map, Transform)) {
+public func <- <Transform: TransformType>(left: inout [Transform.Object], right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let values = fromJSONArrayWithTransform(map.currentValue, transform: transform)
 		FromJSON.basicType(&left, object: values)
-	case .ToJSON:
+	case .tojson:
 		let values = toJSONArrayWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(values, map: map)
 	default: ()
@@ -179,13 +179,13 @@ public func <- <Transform: TransformType>(inout left: [Transform.Object], right:
 }
 
 /// Optional array of Basic type with Transform
-public func <- <Transform: TransformType>(inout left: [Transform.Object]?, right: (Map, Transform)) {
+public func <- <Transform: TransformType>(left: inout [Transform.Object]?, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let values = fromJSONArrayWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: values)
-	case .ToJSON:
+	case .tojson:
 		let values = toJSONArrayWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(values, map: map)
 	default: ()
@@ -193,13 +193,13 @@ public func <- <Transform: TransformType>(inout left: [Transform.Object]?, right
 }
 
 /// Implicitly unwrapped optional array of Basic type with Transform
-public func <- <Transform: TransformType>(inout left: [Transform.Object]!, right: (Map, Transform)) {
+public func <- <Transform: TransformType>(left: inout [Transform.Object]!, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let values = fromJSONArrayWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: values)
-	case .ToJSON:
+	case .tojson:
 		let values = toJSONArrayWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(values, map: map)
 	default: ()
@@ -207,13 +207,13 @@ public func <- <Transform: TransformType>(inout left: [Transform.Object]!, right
 }
 
 /// Dictionary of Basic type with Transform
-public func <- <Transform: TransformType>(inout left: [String: Transform.Object], right: (Map, Transform)) {
+public func <- <Transform: TransformType>(left: inout [String: Transform.Object], right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let values = fromJSONDictionaryWithTransform(map.currentValue, transform: transform)
 		FromJSON.basicType(&left, object: values)
-	case .ToJSON:
+	case .tojson:
 		let values = toJSONDictionaryWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(values, map: map)
 	default: ()
@@ -221,13 +221,13 @@ public func <- <Transform: TransformType>(inout left: [String: Transform.Object]
 }
 
 /// Optional dictionary of Basic type with Transform
-public func <- <Transform: TransformType>(inout left: [String: Transform.Object]?, right: (Map, Transform)) {
+public func <- <Transform: TransformType>(left: inout [String: Transform.Object]?, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let values = fromJSONDictionaryWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: values)
-	case .ToJSON:
+	case .tojson:
 		let values = toJSONDictionaryWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(values, map: map)
 	default: ()
@@ -235,20 +235,20 @@ public func <- <Transform: TransformType>(inout left: [String: Transform.Object]
 }
 
 /// Implicitly unwrapped optional dictionary of Basic type with Transform
-public func <- <Transform: TransformType>(inout left: [String: Transform.Object]!, right: (Map, Transform)) {
+public func <- <Transform: TransformType>(left: inout [String: Transform.Object]!, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let values = fromJSONDictionaryWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: values)
-	case .ToJSON:
+	case .tojson:
 		let values = toJSONDictionaryWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(values, map: map)
 	default: ()
 	}
 }
 
-private func fromJSONArrayWithTransform<Transform: TransformType>(input: AnyObject?, transform: Transform) -> [Transform.Object]? {
+private func fromJSONArrayWithTransform<Transform: TransformType>(_ input: AnyObject?, transform: Transform) -> [Transform.Object]? {
 	if let values = input as? [AnyObject] {
 		return values.flatMap { value in
 			return transform.transformFromJSON(value)
@@ -258,7 +258,7 @@ private func fromJSONArrayWithTransform<Transform: TransformType>(input: AnyObje
 	}
 }
 
-private func fromJSONDictionaryWithTransform<Transform: TransformType>(input: AnyObject?, transform: Transform) -> [String: Transform.Object]? {
+private func fromJSONDictionaryWithTransform<Transform: TransformType>(_ input: AnyObject?, transform: Transform) -> [String: Transform.Object]? {
 	if let values = input as? [String: AnyObject] {
 		return values.filterMap { value in
 			return transform.transformFromJSON(value)
@@ -268,13 +268,13 @@ private func fromJSONDictionaryWithTransform<Transform: TransformType>(input: An
 	}
 }
 
-private func toJSONArrayWithTransform<Transform: TransformType>(input: [Transform.Object]?, transform: Transform) -> [Transform.JSON]? {
+private func toJSONArrayWithTransform<Transform: TransformType>(_ input: [Transform.Object]?, transform: Transform) -> [Transform.JSON]? {
 	return input?.flatMap { value in
 		return transform.transformToJSON(value)
 	}
 }
 
-private func toJSONDictionaryWithTransform<Transform: TransformType>(input: [String: Transform.Object]?, transform: Transform) -> [String: Transform.JSON]? {
+private func toJSONDictionaryWithTransform<Transform: TransformType>(_ input: [String: Transform.Object]?, transform: Transform) -> [String: Transform.JSON]? {
 	return input?.filterMap { value in
 		return transform.transformToJSON(value)
 	}
@@ -283,32 +283,32 @@ private func toJSONDictionaryWithTransform<Transform: TransformType>(input: [Str
 // MARK:- Mappable Objects - <T: Mappable>
 
 /// Object conforming to Mappable
-public func <- <T: Mappable>(inout left: T, right: Map) {
+public func <- <T: Mappable>(left: inout T, right: Map) {
 	switch right.mappingType {
-	case .FromJSON:
+	case .fromJSON:
 		FromJSON.object(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.object(left, map: right)
 	}
 }
 
 /// Optional Mappable objects
-public func <- <T: Mappable>(inout left: T?, right: Map) {
+public func <- <T: Mappable>(left: inout T?, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalObject(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalObject(left, map: right)
 	default: ()
 	}
 }
 
 /// Implicitly unwrapped optional Mappable objects
-public func <- <T: Mappable>(inout left: T!, right: Map) {
+public func <- <T: Mappable>(left: inout T!, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalObject(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalObject(left, map: right)
 	default: ()
 	}
@@ -317,13 +317,13 @@ public func <- <T: Mappable>(inout left: T!, right: Map) {
 // MARK:- Transforms of Mappable Objects - <T: Mappable>
 
 /// Object conforming to Mappable that have transforms
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Transform.Object, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Transform.Object, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let value: Transform.Object? = transform.transformFromJSON(map.currentValue)
 		FromJSON.basicType(&left, object: value)
-	case .ToJSON:
+	case .tojson:
 		let value: Transform.JSON? = transform.transformToJSON(left)
 		ToJSON.optionalBasicType(value, map: map)
 	default: ()
@@ -331,13 +331,13 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Optional Mappable objects that have transforms
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Transform.Object?, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Transform.Object?, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let value: Transform.Object? = transform.transformFromJSON(map.currentValue)
 		FromJSON.optionalBasicType(&left, object: value)
-	case .ToJSON:
+	case .tojson:
 		let value: Transform.JSON? = transform.transformToJSON(left)
 		ToJSON.optionalBasicType(value, map: map)
 	default: ()
@@ -345,13 +345,13 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Implicitly unwrapped optional Mappable objects that have transforms
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Transform.Object!, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Transform.Object!, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let value: Transform.Object? = transform.transformFromJSON(map.currentValue)
 		FromJSON.optionalBasicType(&left, object: value)
-	case .ToJSON:
+	case .tojson:
 		let value: Transform.JSON? = transform.transformToJSON(left)
 		ToJSON.optionalBasicType(value, map: map)
 	default: ()
@@ -361,66 +361,66 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 // MARK:- Dictionary of Mappable objects - Dictionary<String, T: Mappable>
 
 /// Dictionary of Mappable objects <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, T>, right: Map) {
+public func <- <T: Mappable>(left: inout Dictionary<String, T>, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.objectDictionary(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.objectDictionary(left, map: right)
 	default: ()
 	}
 }
 
 /// Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, T>?, right: Map) {
+public func <- <T: Mappable>(left: inout Dictionary<String, T>?, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectDictionary(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalObjectDictionary(left, map: right)
 	default: ()
 	}
 }
 
 /// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, T>!, right: Map) {
+public func <- <T: Mappable>(left: inout Dictionary<String, T>!, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectDictionary(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalObjectDictionary(left, map: right)
 	default: ()
 	}
 }
 
 /// Dictionary of Mappable objects <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, [T]>, right: Map) {
+public func <- <T: Mappable>(left: inout Dictionary<String, [T]>, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.objectDictionaryOfArrays(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.objectDictionaryOfArrays(left, map: right)
 	default: ()
 	}
 }
 
 /// Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, [T]>?, right: Map) {
+public func <- <T: Mappable>(left: inout Dictionary<String, [T]>?, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectDictionaryOfArrays(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalObjectDictionaryOfArrays(left, map: right)
 	default: ()
 	}
 }
 
 /// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, [T]>!, right: Map) {
+public func <- <T: Mappable>(left: inout Dictionary<String, [T]>!, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectDictionaryOfArrays(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalObjectDictionaryOfArrays(left, map: right)
 	default: ()
 	}
@@ -429,50 +429,50 @@ public func <- <T: Mappable>(inout left: Dictionary<String, [T]>!, right: Map) {
 // MARK:- Dictionary of Mappable objects with a transform - Dictionary<String, T: Mappable>
 
 /// Dictionary of Mappable objects <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, Transform.Object>, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Dictionary<String, Transform.Object>, right: (Map, Transform)) {
 	let (map, transform) = right
-	if let object = map.currentValue as? [String : AnyObject] where map.mappingType == .FromJSON && map.isKeyPresent {
+	if let object = map.currentValue as? [String : AnyObject] where map.mappingType == .fromJSON && map.isKeyPresent {
 		let value = fromJSONDictionaryWithTransform(object, transform: transform) ?? left
 		FromJSON.basicType(&left, object: value)
-	} else if map.mappingType == .ToJSON {
+	} else if map.mappingType == .tojson {
 		let value = toJSONDictionaryWithTransform(left, transform: transform)
 		ToJSON.basicType(value, map: map)
 	}
 }
 
 /// Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, Transform.Object>?, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Dictionary<String, Transform.Object>?, right: (Map, Transform)) {
 	let (map, transform) = right
-	if let object = map.currentValue as? [String : AnyObject] where map.mappingType == .FromJSON && map.isKeyPresent {
+	if let object = map.currentValue as? [String : AnyObject] where map.mappingType == .fromJSON && map.isKeyPresent {
 		let value = fromJSONDictionaryWithTransform(object, transform: transform) ?? left
 		FromJSON.optionalBasicType(&left, object: value)
-	} else if map.mappingType == .ToJSON {
+	} else if map.mappingType == .tojson {
 		let value = toJSONDictionaryWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(value, map: map)
 	}
 }
 
 /// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, Transform.Object>!, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Dictionary<String, Transform.Object>!, right: (Map, Transform)) {
 	let (map, transform) = right
-	if let dictionary = map.currentValue as? [String : AnyObject] where map.mappingType == .FromJSON && map.isKeyPresent {
+	if let dictionary = map.currentValue as? [String : AnyObject] where map.mappingType == .fromJSON && map.isKeyPresent {
 		let transformedDictionary = fromJSONDictionaryWithTransform(dictionary, transform: transform) ?? left
 		FromJSON.optionalBasicType(&left, object: transformedDictionary)
-	} else if map.mappingType == .ToJSON {
+	} else if map.mappingType == .tojson {
 		let value = toJSONDictionaryWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(value, map: map)
 	}
 }
 
 /// Dictionary of Mappable objects <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, [Transform.Object]>, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Dictionary<String, [Transform.Object]>, right: (Map, Transform)) {
 	let (map, transform) = right
-	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
+	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .fromJSON && map.isKeyPresent {
 		let transformedDictionary = dictionary.map { (key, values) in
 			return (key, fromJSONArrayWithTransform(values, transform: transform) ?? left[key] ?? [])
 		}
 		FromJSON.basicType(&left, object: transformedDictionary)
-	} else if map.mappingType == .ToJSON {
+	} else if map.mappingType == .tojson {
 		let transformedDictionary = left.map { (key, values) in
 			return (key, toJSONArrayWithTransform(values, transform: transform) ?? [])
 		}
@@ -482,14 +482,14 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, [Transform.Object]>?, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Dictionary<String, [Transform.Object]>?, right: (Map, Transform)) {
 	let (map, transform) = right
-	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
+	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .fromJSON && map.isKeyPresent {
 		let transformedDictionary = dictionary.map { (key, values) in
 			return (key, fromJSONArrayWithTransform(values, transform: transform) ?? left?[key] ?? [])
 		}
 		FromJSON.optionalBasicType(&left, object: transformedDictionary)
-	} else if map.mappingType == .ToJSON {
+	} else if map.mappingType == .tojson {
 		let transformedDictionary = left?.map { (key, values) in
 			return (key, toJSONArrayWithTransform(values, transform: transform) ?? [])
 		}
@@ -499,14 +499,14 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, [Transform.Object]>!, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Dictionary<String, [Transform.Object]>!, right: (Map, Transform)) {
 	let (map, transform) = right
-	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
+	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .fromJSON && map.isKeyPresent {
 		let transformedDictionary = dictionary.map { (key, values) in
 			return (key, fromJSONArrayWithTransform(values, transform: transform) ?? left?[key] ?? [])
 		}
 		FromJSON.optionalBasicType(&left, object: transformedDictionary)
-	} else if map.mappingType == .ToJSON {
+	} else if map.mappingType == .tojson {
 		let transformedDictionary = left?.map { (key, values) in
 			return (key, toJSONArrayWithTransform(values, transform: transform) ?? [])
 		}
@@ -518,33 +518,33 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 // MARK:- Array of Mappable objects - Array<T: Mappable>
 
 /// Array of Mappable objects
-public func <- <T: Mappable>(inout left: Array<T>, right: Map) {
+public func <- <T: Mappable>(left: inout Array<T>, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.objectArray(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.objectArray(left, map: right)
 	default: ()
 	}
 }
 
 /// Optional array of Mappable objects
-public func <- <T: Mappable>(inout left: Array<T>?, right: Map) {
+public func <- <T: Mappable>(left: inout Array<T>?, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectArray(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalObjectArray(left, map: right)
 	default: ()
 	}
 }
 
 /// Implicitly unwrapped Optional array of Mappable objects
-public func <- <T: Mappable>(inout left: Array<T>!, right: Map) {
+public func <- <T: Mappable>(left: inout Array<T>!, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectArray(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalObjectArray(left, map: right)
 	default: ()
 	}
@@ -553,14 +553,14 @@ public func <- <T: Mappable>(inout left: Array<T>!, right: Map) {
 // MARK:- Array of Mappable objects with transforms - Array<T: Mappable>
 
 /// Array of Mappable objects
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Array<Transform.Object>, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Array<Transform.Object>, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		if let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform) {
 			FromJSON.basicType(&left, object: transformedValues)
 		}
-	case .ToJSON:
+	case .tojson:
 		let transformedValues = toJSONArrayWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(transformedValues, map: map)
 	default: ()
@@ -568,13 +568,13 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Optional array of Mappable objects
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Array<Transform.Object>?, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Array<Transform.Object>?, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: transformedValues)
-	case .ToJSON:
+	case .tojson:
 		let transformedValues = toJSONArrayWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(transformedValues, map: map)
 	default: ()
@@ -582,13 +582,13 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Implicitly unwrapped Optional array of Mappable objects
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Array<Transform.Object>!, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Array<Transform.Object>!, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: transformedValues)
-	case .ToJSON:
+	case .tojson:
 		let transformedValues = toJSONArrayWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(transformedValues, map: map)
 	default: ()
@@ -598,33 +598,33 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 // MARK:- Array of Array of Mappable objects - Array<Array<T: Mappable>>
 
 /// Array of Array Mappable objects
-public func <- <T: Mappable>(inout left: Array<Array<T>>, right: Map) {
+public func <- <T: Mappable>(left: inout Array<Array<T>>, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.twoDimensionalObjectArray(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.twoDimensionalObjectArray(left, map: right)
 	default: ()
 	}
 }
 
 /// Optional array of Mappable objects
-public func <- <T: Mappable>(inout left:Array<Array<T>>?, right: Map) {
+public func <- <T: Mappable>(left:inout Array<Array<T>>?, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalTwoDimensionalObjectArray(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalTwoDimensionalObjectArray(left, map: right)
 	default: ()
 	}
 }
 
 /// Implicitly unwrapped Optional array of Mappable objects
-public func <- <T: Mappable>(inout left: Array<Array<T>>!, right: Map) {
+public func <- <T: Mappable>(left: inout Array<Array<T>>!, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalTwoDimensionalObjectArray(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalTwoDimensionalObjectArray(left, map: right)
 	default: ()
 	}
@@ -633,14 +633,14 @@ public func <- <T: Mappable>(inout left: Array<Array<T>>!, right: Map) {
 // MARK:- Array of Array of Mappable objects - Array<Array<T: Mappable>> with transforms
 
 /// Array of Array Mappable objects with transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Array<Array<Transform.Object>>, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Array<Array<Transform.Object>>, right: (Map, Transform)) {
 	let (map, transform) = right
-	if let original2DArray = map.currentValue as? [[AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
+	if let original2DArray = map.currentValue as? [[AnyObject]] where map.mappingType == .fromJSON && map.isKeyPresent {
 		let transformed2DArray = original2DArray.flatMap { values in
 			fromJSONArrayWithTransform(values, transform: transform)
 		}
 		FromJSON.basicType(&left, object: transformed2DArray)
-	} else if map.mappingType == .ToJSON {
+	} else if map.mappingType == .tojson {
 		let transformed2DArray = left.flatMap { values in
 			toJSONArrayWithTransform(values, transform: transform)
 		}
@@ -649,14 +649,14 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Optional array of Mappable objects with transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left:Array<Array<Transform.Object>>?, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left:inout Array<Array<Transform.Object>>?, right: (Map, Transform)) {
 	let (map, transform) = right
-	if let original2DArray = map.currentValue as? [[AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
+	if let original2DArray = map.currentValue as? [[AnyObject]] where map.mappingType == .fromJSON && map.isKeyPresent {
 		let transformed2DArray = original2DArray.flatMap { values in
 			fromJSONArrayWithTransform(values, transform: transform)
 		}
 		FromJSON.optionalBasicType(&left, object: transformed2DArray)
-	} else if map.mappingType == .ToJSON {
+	} else if map.mappingType == .tojson {
 		let transformed2DArray = left?.flatMap { values in
 			toJSONArrayWithTransform(values, transform: transform)
 		}
@@ -665,14 +665,14 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Implicitly unwrapped Optional array of Mappable objects with transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Array<Array<Transform.Object>>!, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: Mappable>(left: inout Array<Array<Transform.Object>>!, right: (Map, Transform)) {
 	let (map, transform) = right
-	if let original2DArray = map.currentValue as? [[AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
+	if let original2DArray = map.currentValue as? [[AnyObject]] where map.mappingType == .fromJSON && map.isKeyPresent {
 		let transformed2DArray = original2DArray.flatMap { values in
 			fromJSONArrayWithTransform(values, transform: transform)
 		}
 		FromJSON.optionalBasicType(&left, object: transformed2DArray)
-	} else if map.mappingType == .ToJSON {
+	} else if map.mappingType == .tojson {
 		let transformed2DArray = left?.flatMap { values in
 			toJSONArrayWithTransform(values, transform: transform)
 		}
@@ -683,11 +683,11 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 // MARK:- Set of Mappable objects - Set<T: Mappable where T: Hashable>
 
 /// Set of Mappable objects
-public func <- <T: Mappable where T: Hashable>(inout left: Set<T>, right: Map) {
+public func <- <T: Mappable where T: Hashable>(left: inout Set<T>, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.objectSet(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.objectSet(left, map: right)
 	default: ()
 	}
@@ -695,22 +695,22 @@ public func <- <T: Mappable where T: Hashable>(inout left: Set<T>, right: Map) {
 
 
 /// Optional Set of Mappable objects
-public func <- <T: Mappable where T: Hashable>(inout left: Set<T>?, right: Map) {
+public func <- <T: Mappable where T: Hashable>(left: inout Set<T>?, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectSet(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalObjectSet(left, map: right)
 	default: ()
 	}
 }
 
 /// Implicitly unwrapped Optional Set of Mappable objects
-public func <- <T: Mappable where T: Hashable>(inout left: Set<T>!, right: Map) {
+public func <- <T: Mappable where T: Hashable>(left: inout Set<T>!, right: Map) {
 	switch right.mappingType {
-	case .FromJSON where right.isKeyPresent:
+	case .fromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectSet(&left, map: right)
-	case .ToJSON:
+	case .tojson:
 		ToJSON.optionalObjectSet(left, map: right)
 	default: ()
 	}
@@ -720,14 +720,14 @@ public func <- <T: Mappable where T: Hashable>(inout left: Set<T>!, right: Map) 
 // MARK:- Set of Mappable objects with a transform - Set<T: Mappable where T: Hashable>
 
 /// Set of Mappable objects with transform
-public func <- <Transform: TransformType where Transform.Object: protocol<Hashable, Mappable>>(inout left: Set<Transform.Object>, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: protocol<Hashable, Mappable>>(left: inout Set<Transform.Object>, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		if let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform) {
 			FromJSON.basicType(&left, object: Set(transformedValues))
 		}
-	case .ToJSON:
+	case .tojson:
 		let transformedValues = toJSONArrayWithTransform(Array(left), transform: transform)
 		ToJSON.optionalBasicType(transformedValues, map: map)
 	default: ()
@@ -736,14 +736,14 @@ public func <- <Transform: TransformType where Transform.Object: protocol<Hashab
 
 
 /// Optional Set of Mappable objects with transform
-public func <- <Transform: TransformType where Transform.Object: protocol<Hashable, Mappable>>(inout left: Set<Transform.Object>?, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: protocol<Hashable, Mappable>>(left: inout Set<Transform.Object>?, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		if let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform) {
 			FromJSON.basicType(&left, object: Set(transformedValues))
 		}
-	case .ToJSON:
+	case .tojson:
 		if let values = left {
 			let transformedValues = toJSONArrayWithTransform(Array(values), transform: transform)
 			ToJSON.optionalBasicType(transformedValues, map: map)
@@ -753,14 +753,14 @@ public func <- <Transform: TransformType where Transform.Object: protocol<Hashab
 }
 
 /// Implicitly unwrapped Optional set of Mappable objects with transform
-public func <- <Transform: TransformType where Transform.Object: protocol<Hashable, Mappable>>(inout left: Set<Transform.Object>!, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: protocol<Hashable, Mappable>>(left: inout Set<Transform.Object>!, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .FromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent:
 		if let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform) {
 			FromJSON.basicType(&left, object: Set(transformedValues))
 		}
-	case .ToJSON:
+	case .tojson:
 		if let values = left {
 			let transformedValues = toJSONArrayWithTransform(Array(values), transform: transform)
 			ToJSON.optionalBasicType(transformedValues, map: map)

--- a/ObjectMapper/Core/ToJSON.swift
+++ b/ObjectMapper/Core/ToJSON.swift
@@ -28,11 +28,11 @@
 
 import class Foundation.NSNumber
 
-private func setValue(value: AnyObject, map: Map) {
+private func setValue(_ value: AnyObject, map: Map) {
 	setValue(value, key: map.currentKey!, checkForNestedKeys: map.keyIsNested, dictionary: &map.JSONDictionary)
 }
 
-private func setValue(value: AnyObject, key: String, checkForNestedKeys: Bool, inout dictionary: [String : AnyObject]) {
+private func setValue(_ value: AnyObject, key: String, checkForNestedKeys: Bool, dictionary: inout [String : AnyObject]) {
 	if checkForNestedKeys {
 		let keyComponents = ArraySlice(key.characters.split { $0 == "." })
 		setValue(value, forKeyPathComponents: keyComponents, dictionary: &dictionary)
@@ -41,7 +41,7 @@ private func setValue(value: AnyObject, key: String, checkForNestedKeys: Bool, i
 	}
 }
 
-private func setValue(value: AnyObject, forKeyPathComponents components: ArraySlice<String.CharacterView.SubSequence>, inout dictionary: [String : AnyObject]) {
+private func setValue(_ value: AnyObject, forKeyPathComponents components: ArraySlice<String.CharacterView.SubSequence>, dictionary: inout [String : AnyObject]) {
 	if components.isEmpty {
 		return
 	}
@@ -65,7 +65,7 @@ private func setValue(value: AnyObject, forKeyPathComponents components: ArraySl
 
 internal final class ToJSON {
 	
-	class func basicType<N>(field: N, map: Map) {
+	class func basicType<N>(_ field: N, map: Map) {
 		if let x = field as? AnyObject where false
 			|| x is NSNumber // Basic types
 			|| x is Bool
@@ -93,35 +93,35 @@ internal final class ToJSON {
 		}
 	}
 
-	class func optionalBasicType<N>(field: N?, map: Map) {
+	class func optionalBasicType<N>(_ field: N?, map: Map) {
 		if let field = field {
 			basicType(field, map: map)
 		}
 	}
 
-	class func object<N: Mappable>(field: N, map: Map) {
+	class func object<N: Mappable>(_ field: N, map: Map) {
 		setValue(Mapper(context: map.context).toJSON(field), map: map)
 	}
 	
-	class func optionalObject<N: Mappable>(field: N?, map: Map) {
+	class func optionalObject<N: Mappable>(_ field: N?, map: Map) {
 		if let field = field {
 			object(field, map: map)
 		}
 	}
 
-	class func objectArray<N: Mappable>(field: Array<N>, map: Map) {
+	class func objectArray<N: Mappable>(_ field: Array<N>, map: Map) {
 		let JSONObjects = Mapper(context: map.context).toJSONArray(field)
 		
 		setValue(JSONObjects, map: map)
 	}
 	
-	class func optionalObjectArray<N: Mappable>(field: Array<N>?, map: Map) {
+	class func optionalObjectArray<N: Mappable>(_ field: Array<N>?, map: Map) {
 		if let field = field {
 			objectArray(field, map: map)
 		}
 	}
 	
-	class func twoDimensionalObjectArray<N: Mappable>(field: Array<Array<N>>, map: Map) {
+	class func twoDimensionalObjectArray<N: Mappable>(_ field: Array<Array<N>>, map: Map) {
 		var array = [[[String : AnyObject]]]()
 		for innerArray in field {
 			let JSONObjects = Mapper(context: map.context).toJSONArray(innerArray)
@@ -130,43 +130,43 @@ internal final class ToJSON {
 		setValue(array, map: map)
 	}
 	
-	class func optionalTwoDimensionalObjectArray<N: Mappable>(field: Array<Array<N>>?, map: Map) {
+	class func optionalTwoDimensionalObjectArray<N: Mappable>(_ field: Array<Array<N>>?, map: Map) {
 		if let field = field {
 			twoDimensionalObjectArray(field, map: map)
 		}
 	}
 	
-	class func objectSet<N: Mappable where N: Hashable>(field: Set<N>, map: Map) {
+	class func objectSet<N: Mappable where N: Hashable>(_ field: Set<N>, map: Map) {
 		let JSONObjects = Mapper(context: map.context).toJSONSet(field)
 		
 		setValue(JSONObjects, map: map)
 	}
 	
-	class func optionalObjectSet<N: Mappable where N: Hashable>(field: Set<N>?, map: Map) {
+	class func optionalObjectSet<N: Mappable where N: Hashable>(_ field: Set<N>?, map: Map) {
 		if let field = field {
 			objectSet(field, map: map)
 		}
 	}
 	
-	class func objectDictionary<N: Mappable>(field: Dictionary<String, N>, map: Map) {
+	class func objectDictionary<N: Mappable>(_ field: Dictionary<String, N>, map: Map) {
 		let JSONObjects = Mapper(context: map.context).toJSONDictionary(field)
 		
 		setValue(JSONObjects, map: map)
 	}
 	
-	class func optionalObjectDictionary<N: Mappable>(field: Dictionary<String, N>?, map: Map) {
+	class func optionalObjectDictionary<N: Mappable>(_ field: Dictionary<String, N>?, map: Map) {
         if let field = field {
 			objectDictionary(field, map: map)
         }
     }
 	
-	class func objectDictionaryOfArrays<N: Mappable>(field: Dictionary<String, [N]>, map: Map) {
+	class func objectDictionaryOfArrays<N: Mappable>(_ field: Dictionary<String, [N]>, map: Map) {
 		let JSONObjects = Mapper(context: map.context).toJSONDictionaryOfArrays(field)
 
 		setValue(JSONObjects, map: map)
 	}
 	
-	class func optionalObjectDictionaryOfArrays<N: Mappable>(field: Dictionary<String, [N]>?, map: Map) {
+	class func optionalObjectDictionaryOfArrays<N: Mappable>(_ field: Dictionary<String, [N]>?, map: Map) {
 		if let field = field {
 			objectDictionaryOfArrays(field, map: map)
 		}

--- a/ObjectMapper/Transforms/CustomDateFormatTransform.swift
+++ b/ObjectMapper/Transforms/CustomDateFormatTransform.swift
@@ -31,8 +31,8 @@ import Foundation
 public class CustomDateFormatTransform: DateFormatterTransform {
 	
     public init(formatString: String) {
-		let formatter = NSDateFormatter()
-		formatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+		let formatter = DateFormatter()
+		formatter.locale = Locale(localeIdentifier: "en_US_POSIX")
 		formatter.dateFormat = formatString
 		
 		super.init(dateFormatter: formatter)

--- a/ObjectMapper/Transforms/DateFormatterTransform.swift
+++ b/ObjectMapper/Transforms/DateFormatterTransform.swift
@@ -29,25 +29,25 @@
 import Foundation
 
 public class DateFormatterTransform: TransformType {
-	public typealias Object = NSDate
+	public typealias Object = Date
 	public typealias JSON = String
 	
-	let dateFormatter: NSDateFormatter
+	let dateFormatter: DateFormatter
 	
-	public init(dateFormatter: NSDateFormatter) {
+	public init(dateFormatter: DateFormatter) {
 		self.dateFormatter = dateFormatter
 	}
 	
-	public func transformFromJSON(value: AnyObject?) -> NSDate? {
+	public func transformFromJSON(_ value: AnyObject?) -> Date? {
 		if let dateString = value as? String {
-			return dateFormatter.dateFromString(dateString)
+			return dateFormatter.date(from: dateString)
 		}
 		return nil
 	}
 	
-	public func transformToJSON(value: NSDate?) -> String? {
+	public func transformToJSON(_ value: Date?) -> String? {
 		if let date = value {
-			return dateFormatter.stringFromDate(date)
+			return dateFormatter.string(from: date)
 		}
 		return nil
 	}

--- a/ObjectMapper/Transforms/DateTransform.swift
+++ b/ObjectMapper/Transforms/DateTransform.swift
@@ -29,24 +29,24 @@
 import Foundation
 
 public class DateTransform: TransformType {
-	public typealias Object = NSDate
+	public typealias Object = Date
 	public typealias JSON = Double
 
 	public init() {}
 
-	public func transformFromJSON(value: AnyObject?) -> NSDate? {
+	public func transformFromJSON(_ value: AnyObject?) -> Date? {
 		if let timeInt = value as? Double {
-			return NSDate(timeIntervalSince1970: NSTimeInterval(timeInt))
+			return Date(timeIntervalSince1970: TimeInterval(timeInt))
 		}
 		
 		if let timeStr = value as? String {
-			return NSDate(timeIntervalSince1970: NSTimeInterval(atof(timeStr)))
+			return Date(timeIntervalSince1970: TimeInterval(atof(timeStr)))
 		}
 		
 		return nil
 	}
 
-	public func transformToJSON(value: NSDate?) -> Double? {
+	public func transformToJSON(_ value: Date?) -> Double? {
 		if let date = value {
 			return Double(date.timeIntervalSince1970)
 		}

--- a/ObjectMapper/Transforms/EnumTransform.swift
+++ b/ObjectMapper/Transforms/EnumTransform.swift
@@ -34,14 +34,14 @@ public class EnumTransform<T: RawRepresentable>: TransformType {
 	
 	public init() {}
 	
-	public func transformFromJSON(value: AnyObject?) -> T? {
+	public func transformFromJSON(_ value: AnyObject?) -> T? {
 		if let raw = value as? T.RawValue {
 			return T(rawValue: raw)
 		}
 		return nil
 	}
 	
-	public func transformToJSON(value: T?) -> T.RawValue? {
+	public func transformToJSON(_ value: T?) -> T.RawValue? {
 		if let obj = value {
 			return obj.rawValue
 		}

--- a/ObjectMapper/Transforms/ISO8601DateTransform.swift
+++ b/ObjectMapper/Transforms/ISO8601DateTransform.swift
@@ -31,8 +31,8 @@ import Foundation
 public class ISO8601DateTransform: DateFormatterTransform {
 
 	public init() {
-		let formatter = NSDateFormatter()
-		formatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+		let formatter = DateFormatter()
+		formatter.locale = Locale(localeIdentifier: "en_US_POSIX")
 		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
 		
 		super.init(dateFormatter: formatter)

--- a/ObjectMapper/Transforms/NSDecimalNumberTransform.swift
+++ b/ObjectMapper/Transforms/NSDecimalNumberTransform.swift
@@ -6,17 +6,17 @@ public class NSDecimalNumberTransform: TransformType {
 
     public init() {}
 
-    public func transformFromJSON(value: AnyObject?) -> NSDecimalNumber? {
+    public func transformFromJSON(_ value: AnyObject?) -> NSDecimalNumber? {
         if let string = value as? String {
             return NSDecimalNumber(string: string)
         }
         if let double = value as? Double {
-            return NSDecimalNumber(double: double)
+            return NSDecimalNumber(value: double)
         }
         return nil
     }
 
-    public func transformToJSON(value: NSDecimalNumber?) -> String? {
+    public func transformToJSON(_ value: NSDecimalNumber?) -> String? {
         guard let value = value else { return nil }
         return value.description
     }

--- a/ObjectMapper/Transforms/TransformOf.swift
+++ b/ObjectMapper/Transforms/TransformOf.swift
@@ -30,19 +30,19 @@ public class TransformOf<ObjectType, JSONType>: TransformType {
 	public typealias Object = ObjectType
 	public typealias JSON = JSONType
 
-	private let fromJSON: JSONType? -> ObjectType?
-	private let toJSON: ObjectType? -> JSONType?
+	private let fromJSON: (JSONType?) -> ObjectType?
+	private let toJSON: (ObjectType?) -> JSONType?
 
-	public init(fromJSON: JSONType? -> ObjectType?, toJSON: ObjectType? -> JSONType?) {
+	public init(fromJSON: (JSONType?) -> ObjectType?, toJSON: (ObjectType?) -> JSONType?) {
 		self.fromJSON = fromJSON
 		self.toJSON = toJSON
 	}
 
-	public func transformFromJSON(value: AnyObject?) -> ObjectType? {
+	public func transformFromJSON(_ value: AnyObject?) -> ObjectType? {
 		return fromJSON(value as? JSONType)
 	}
 
-	public func transformToJSON(value: ObjectType?) -> JSONType? {
+	public func transformToJSON(_ value: ObjectType?) -> JSONType? {
 		return toJSON(value)
 	}
 }

--- a/ObjectMapper/Transforms/TransformType.swift
+++ b/ObjectMapper/Transforms/TransformType.swift
@@ -30,6 +30,6 @@ public protocol TransformType {
 	associatedtype Object
 	associatedtype JSON
 
-	func transformFromJSON(value: AnyObject?) -> Object?
-	func transformToJSON(value: Object?) -> JSON?
+	func transformFromJSON(_ value: AnyObject?) -> Object?
+	func transformToJSON(_ value: Object?) -> JSON?
 }

--- a/ObjectMapper/Transforms/URLTransform.swift
+++ b/ObjectMapper/Transforms/URLTransform.swift
@@ -29,19 +29,19 @@
 import Foundation
 
 public class URLTransform: TransformType {
-	public typealias Object = NSURL
+	public typealias Object = URL
 	public typealias JSON = String
 
 	public init() {}
 
-	public func transformFromJSON(value: AnyObject?) -> NSURL? {
+	public func transformFromJSON(_ value: AnyObject?) -> URL? {
 		if let URLString = value as? String {
-			return NSURL(string: URLString)
+			return URL(string: URLString)
 		}
 		return nil
 	}
 
-	public func transformToJSON(value: NSURL?) -> String? {
+	public func transformToJSON(_ value: URL?) -> String? {
 		if let URL = value {
 			return URL.absoluteString
 		}

--- a/ObjectMapperTests/BasicTypes.swift
+++ b/ObjectMapperTests/BasicTypes.swift
@@ -88,26 +88,26 @@ class BasicTypes: Mappable {
 	var dictAnyObjectImplicitlyUnwrapped: Dictionary<String, AnyObject>!
 
 	enum EnumInt: Int {
-		case Default
-		case Another
+		case `default`
+		case another
 	}
-	var enumInt: EnumInt = .Default
+	var enumInt: EnumInt = .default
 	var enumIntOptional: EnumInt?
 	var enumIntImplicitlyUnwrapped: EnumInt!
 
 	enum EnumDouble: Double {
-		case Default
-		case Another
+		case `default`
+		case another
 	}
-	var enumDouble: EnumDouble = .Default
+	var enumDouble: EnumDouble = .default
 	var enumDoubleOptional: EnumDouble?
 	var enumDoubleImplicitlyUnwrapped: EnumDouble!
 
 	enum EnumFloat: Float {
-		case Default
-		case Another
+		case `default`
+		case another
 	}
-	var enumFloat: EnumFloat = .Default
+	var enumFloat: EnumFloat = .default
 	var enumFloatOptional: EnumFloat?
 	var enumFloatImplicitlyUnwrapped: EnumFloat!
 
@@ -135,7 +135,7 @@ class BasicTypes: Mappable {
 
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		bool								<- map["bool"]
 		boolOptional						<- map["boolOpt"]
 		boolImplicityUnwrapped				<- map["boolImp"]
@@ -242,7 +242,7 @@ class TestCollectionOfPrimitives : Mappable {
 		}
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		dictStringString    <- map["dictStringString"]
 		dictStringBool      <- map["dictStringBool"]
 		dictStringInt       <- map["dictStringInt"]

--- a/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -291,7 +291,7 @@ class BasicTypesTestsFromJSON: XCTestCase {
 	}
 
 	func testMappingIntEnumFromJSON(){
-		let value: BasicTypes.EnumInt = .Another
+		let value: BasicTypes.EnumInt = .another
 		let JSONString = "{\"enumInt\" : \(value.rawValue), \"enumIntOpt\" : \(value.rawValue), \"enumIntImp\" : \(value.rawValue) }"
 
 		let mappedObject = mapper.map(JSONString)
@@ -309,13 +309,13 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		let mappedObject = mapper.map(JSONString)
 		
 		XCTAssertNotNil(mappedObject)
-		XCTAssertEqual(mappedObject?.enumInt, BasicTypes.EnumInt.Default)
+		XCTAssertEqual(mappedObject?.enumInt, BasicTypes.EnumInt.default)
 		XCTAssertNil(mappedObject?.enumIntOptional)
 		XCTAssertNil(mappedObject?.enumIntImplicitlyUnwrapped)
 	}
 
 	func testMappingDoubleEnumFromJSON(){
-		let value: BasicTypes.EnumDouble = .Another
+		let value: BasicTypes.EnumDouble = .another
 		let JSONString = "{\"enumDouble\" : \(value.rawValue), \"enumDoubleOpt\" : \(value.rawValue), \"enumDoubleImp\" : \(value.rawValue) }"
 
 		let mappedObject = mapper.map(JSONString)
@@ -327,7 +327,7 @@ class BasicTypesTestsFromJSON: XCTestCase {
 	}
 
 	func testMappingFloatEnumFromJSON(){
-		let value: BasicTypes.EnumFloat = .Another
+		let value: BasicTypes.EnumFloat = .another
 		let JSONString = "{\"enumFloat\" : \(value.rawValue), \"enumFloatOpt\" : \(value.rawValue), \"enumFloatImp\" : \(value.rawValue) }"
 
 		let mappedObject = mapper.map(JSONString)
@@ -351,7 +351,7 @@ class BasicTypesTestsFromJSON: XCTestCase {
 	}
 
 	func testMappingEnumIntArrayFromJSON(){
-		let value: BasicTypes.EnumInt = .Another
+		let value: BasicTypes.EnumInt = .another
 		let JSONString = "{ \"arrayEnumInt\" : [\(value.rawValue)], \"arrayEnumIntOpt\" : [\(value.rawValue)], \"arrayEnumIntImp\" : [\(value.rawValue)] }"
 
 		let mappedObject = mapper.map(JSONString)
@@ -376,7 +376,7 @@ class BasicTypesTestsFromJSON: XCTestCase {
 
 	func testMappingEnumIntDictionaryFromJSON(){
 		let key = "key"
-		let value: BasicTypes.EnumInt = .Another
+		let value: BasicTypes.EnumInt = .another
 		let JSONString = "{ \"dictEnumInt\" : { \"\(key)\" : \(value.rawValue) }, \"dictEnumIntOpt\" : { \"\(key)\" : \(value.rawValue) }, \"dictEnumIntImp\" : { \"\(key)\" : \(value.rawValue) } }"
 
 		let mappedObject = mapper.map(JSONString)

--- a/ObjectMapperTests/BasicTypesTestsToJSON.swift
+++ b/ObjectMapperTests/BasicTypesTestsToJSON.swift
@@ -375,7 +375,7 @@ class BasicTypesTestsToJSON: XCTestCase {
 	}
 
 	func testMappingIntEnumToJSON(){
-		let value = BasicTypes.EnumInt.Another
+		let value = BasicTypes.EnumInt.another
 		let object = BasicTypes()
 		object.enumInt = value
 		object.enumIntOptional = value
@@ -391,7 +391,7 @@ class BasicTypesTestsToJSON: XCTestCase {
 	}
 
 	func testMappingDoubleEnumToJSON(){
-		let value = BasicTypes.EnumDouble.Another
+		let value = BasicTypes.EnumDouble.another
 		let object = BasicTypes()
 		object.enumDouble = value
 		object.enumDoubleOptional = value
@@ -407,7 +407,7 @@ class BasicTypesTestsToJSON: XCTestCase {
 	}
 
 	func testMappingFloatEnumToJSON(){
-		let value = BasicTypes.EnumFloat.Another
+		let value = BasicTypes.EnumFloat.another
 		let object = BasicTypes()
 		object.enumFloat = value
 		object.enumFloatOptional = value
@@ -439,7 +439,7 @@ class BasicTypesTestsToJSON: XCTestCase {
 	}
 
 	func testMappingEnumIntArrayToJSON(){
-		let value = BasicTypes.EnumInt.Another
+		let value = BasicTypes.EnumInt.another
 		let object = BasicTypes()
 		object.arrayEnumInt = [value]
 		object.arrayEnumIntOptional = [value]
@@ -456,7 +456,7 @@ class BasicTypesTestsToJSON: XCTestCase {
 
 	func testMappingEnumIntDictionaryToJSON(){
 		let key = "key"
-		let value = BasicTypes.EnumInt.Another
+		let value = BasicTypes.EnumInt.another
 		let object = BasicTypes()
 		object.dictEnumInt = [key: value]
 		object.dictEnumIntOptional = [key: value]

--- a/ObjectMapperTests/ClassClusterTests.swift
+++ b/ObjectMapperTests/ClassClusterTests.swift
@@ -63,7 +63,7 @@ class Vehicle: Mappable {
 	
 	var type: String?
 	
-	class func objectForMapping(map: Map) -> Mappable? {
+	class func objectForMapping(_ map: Map) -> Mappable? {
 		if let type: String = map["type"].value() {
 			switch type {
 				case "car":
@@ -81,7 +81,7 @@ class Vehicle: Mappable {
 		
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		type <- map["type"]
 	}
 }
@@ -90,11 +90,11 @@ class Car: Vehicle {
 	
 	var name: String?
 	
-	override class func objectForMapping(map: Map) -> Mappable? {
+	override class func objectForMapping(_ map: Map) -> Mappable? {
 		return nil
 	}
 	
-	override func mapping(map: Map) {
+	override func mapping(_ map: Map) {
 		super.mapping(map)
 		
 		name <- map["name"]
@@ -103,7 +103,7 @@ class Car: Vehicle {
 
 class Bus: Vehicle {
 
-	override func mapping(map: Map) {
+	override func mapping(_ map: Map) {
 		super.mapping(map)
 	}
 }

--- a/ObjectMapperTests/CustomTransformTests.swift
+++ b/ObjectMapperTests/CustomTransformTests.swift
@@ -46,8 +46,8 @@ class CustomTransformTests: XCTestCase {
 
 	func testDateTransform() {
 		let transforms = Transforms()
-		transforms.date = NSDate(timeIntervalSince1970: 946684800)
-		transforms.dateOpt = NSDate(timeIntervalSince1970: 946684912)
+		transforms.date = Date(timeIntervalSince1970: 946684800)
+		transforms.dateOpt = Date(timeIntervalSince1970: 946684912)
 		
 		let JSON = mapper.toJSON(transforms)
 		let parsedTransforms = mapper.map(JSON)
@@ -66,8 +66,8 @@ class CustomTransformTests: XCTestCase {
 	
 	func testISO8601DateTransform() {
 		let transforms = Transforms()
-		transforms.ISO8601Date = NSDate(timeIntervalSince1970: 1398956159)
-		transforms.ISO8601DateOpt = NSDate(timeIntervalSince1970: 1398956159)
+		transforms.ISO8601Date = Date(timeIntervalSince1970: 1398956159)
+		transforms.ISO8601DateOpt = Date(timeIntervalSince1970: 1398956159)
 		let JSON = mapper.toJSON(transforms)
 
 		let parsedTransforms = mapper.map(JSON)
@@ -121,8 +121,8 @@ class CustomTransformTests: XCTestCase {
 	
 	func testURLTranform() {
 		let transforms = Transforms()
-		transforms.URL = NSURL(string: "http://google.com/image/1234")!
-		transforms.URLOpt = NSURL(string: "http://google.com/image/1234")
+		transforms.URL = URL(string: "http://google.com/image/1234")!
+		transforms.URLOpt = URL(string: "http://google.com/image/1234")
 		
 		let JSON = mapper.toJSON(transforms)
 
@@ -150,17 +150,17 @@ class Transforms: Mappable {
 		case Thumbnail = "thumbnail"
 	}
 
-	var date = NSDate()
-	var dateOpt: NSDate?
+	var date = Date()
+	var dateOpt: Date?
 	
-	var ISO8601Date: NSDate = NSDate()
-	var ISO8601DateOpt: NSDate?
+	var ISO8601Date: Date = Date()
+	var ISO8601DateOpt: Date?
 	
-	var customFormatDate = NSDate()
-	var customFormatDateOpt: NSDate?
+	var customFormatDate = Date()
+	var customFormatDateOpt: Date?
 	
-	var URL = NSURL()
-	var URLOpt: NSURL?
+	var URL = Foundation.URL(string: "")
+	var URLOpt: Foundation.URL?
 	
 	var intWithString: Int = 0
 	
@@ -177,7 +177,7 @@ class Transforms: Mappable {
 		
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		date				<- (map["date"], DateTransform())
 		dateOpt				<- (map["dateOpt"], DateTransform())
 		
@@ -191,7 +191,7 @@ class Transforms: Mappable {
 		URLOpt				<- (map["URLOpt"], URLTransform())
 		
 		intWithString		<- (map["intWithString"], TransformOf<Int, String>(fromJSON: { $0 == nil ? nil : Int($0!) }, toJSON: { $0.map { String($0) } }))
-		int64Value			<- (map["int64Value"], TransformOf<Int64, NSNumber>(fromJSON: { $0?.longLongValue }, toJSON: { $0.map { NSNumber(longLong: $0) } }))
+		int64Value			<- (map["int64Value"], TransformOf<Int64, NSNumber>(fromJSON: { $0?.int64Value }, toJSON: { $0.map { NSNumber(value: $0) } }))
 		
 		firstImageType		<- (map["firstImageType"], EnumTransform<ImageType>())
 		secondImageType		<- (map["secondImageType"], EnumTransform<ImageType>())

--- a/ObjectMapperTests/IgnoreNilTests.swift
+++ b/ObjectMapperTests/IgnoreNilTests.swift
@@ -52,7 +52,7 @@ class IgnoreNilTests: XCTestCase {
 			
 		}
 		
-		func mapping(map: Map){
+		func mapping(_ map: Map){
 			name <- map["name", ignoreNil: true]
 		}
 	}

--- a/ObjectMapperTests/MapContextTests.swift
+++ b/ObjectMapperTests/MapContextTests.swift
@@ -55,7 +55,7 @@ class MapContextTests: XCTestCase {
 			
 		}
 		
-		func mapping(map: Map) {
+		func mapping(_ map: Map) {
 			if (map.context as? Context)?.shouldMap == true {
 				name <- map["name"]
 			}

--- a/ObjectMapperTests/MappableExtensionsTests.swift
+++ b/ObjectMapperTests/MappableExtensionsTests.swift
@@ -21,7 +21,7 @@ struct TestMappable : Mappable, Equatable, Hashable {
 	init() {}
 	init?(_ map: Map) {	}
 	
-	mutating func mapping(map: Map) {
+	mutating func mapping(_ map: Map) {
 		value <- map["value"]
 	}
 	

--- a/ObjectMapperTests/MappableTypesWithTransformsTests.swift
+++ b/ObjectMapperTests/MappableTypesWithTransformsTests.swift
@@ -252,7 +252,7 @@ class MappableTypesWithTransformsTests: XCTestCase {
 		required init(URI: String) { self.URI = URI }
 		required init?(_ map: Map) {}
 		
-		func mapping(map: Map) {
+		func mapping(_ map: Map) {
 			players		<- (map["players"], RelationshipTransform<Player>())		// 2D Array with transform
 			team1Lineup	<- (map["team1_lineup"], RelationshipTransform<Player>())	// Dictionary with transform
 			team2Lineup	<- (map["team1_lineup"], RelationshipTransform<Player>())
@@ -287,7 +287,7 @@ class MappableTypesWithTransformsTests: XCTestCase {
 		required init(URI: String) { self.URI = URI }
 		required init?(_ map: Map) {}
 		
-		func mapping(map: Map) {
+		func mapping(_ map: Map) {
 			players		<- (map["players"], RelationshipTransform<Player>())
 			O_players	<- (map["players"], RelationshipTransform<Player>())
 			I_players	<- (map["players"], RelationshipTransform<Player>())
@@ -298,7 +298,7 @@ class MappableTypesWithTransformsTests: XCTestCase {
 		required init(URI: String) {}
 		required init?(_ map: Map) {}
 		
-		func mapping(map: Map) {}
+		func mapping(_ map: Map) {}
 	}
 }
 
@@ -310,14 +310,14 @@ class RelationshipTransform<ObjectType where ObjectType: protocol<Mappable, URII
 	typealias Object = ObjectType
 	typealias JSON = [String: AnyObject]
 	
-	func transformFromJSON(value: AnyObject?) -> Object? {
+	func transformFromJSON(_ value: AnyObject?) -> Object? {
 		guard let URI = value as? String else { return nil }
 		let relation = ObjectType(URI: URI)
 		
 		return relation
 	}
 	
-	func transformToJSON(value: Object?) -> JSON? {
+	func transformToJSON(_ value: Object?) -> JSON? {
 		return nil
 	}
 }

--- a/ObjectMapperTests/NSDecimalNumberTransformTests.swift
+++ b/ObjectMapperTests/NSDecimalNumberTransformTests.swift
@@ -15,8 +15,8 @@ class NSDecimalNumberTransformTests: XCTestCase {
         let mappedObject = mapper.map(JSONString)
 
         XCTAssertNotNil(mappedObject)
-        XCTAssertEqual(mappedObject?.int, NSDecimalNumber(integer: int))
-        XCTAssertEqual(mappedObject?.double, NSDecimalNumber(double: double))
+        XCTAssertEqual(mappedObject?.int, NSDecimalNumber(value: int))
+        XCTAssertEqual(mappedObject?.double, NSDecimalNumber(value: double))
         XCTAssertEqual(mappedObject?.intString, NSDecimalNumber(string: intString))
         XCTAssertEqual(mappedObject?.doubleString, NSDecimalNumber(string: doubleString))
     }
@@ -37,7 +37,7 @@ class NSDecimalNumberType: Mappable {
 
     }
 
-    func mapping(map: Map) {
+    func mapping(_ map: Map) {
         int <- (map["int"], NSDecimalNumberTransform())
         double <- (map["double"], NSDecimalNumberTransform())
         intString <- (map["intString"], NSDecimalNumberTransform())

--- a/ObjectMapperTests/NestedArrayTests.swift
+++ b/ObjectMapperTests/NestedArrayTests.swift
@@ -85,7 +85,7 @@ class NestedArray: Mappable {
 		
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		value_0	<- map["nested.0.value"]
 		value_1	<- map["nested.1.value"]
 		
@@ -99,7 +99,7 @@ class NestedObject: Mappable {
 	
 	required init?(_ map: Map){}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		value	<- map["value"]
 	}
 }

--- a/ObjectMapperTests/NestedKeysTests.swift
+++ b/ObjectMapperTests/NestedKeysTests.swift
@@ -46,7 +46,7 @@ class NestedKeysTests: XCTestCase {
 		let JSON: [String: AnyObject] = [
 			"non.nested.key": "string",
 			"nested": [
-				"int64": NSNumber(longLong: INT64_MAX),
+				"int64": NSNumber(value: INT64_MAX),
 				"bool": true,
 				"int": 255,
 				"double": 100.0 as Double,
@@ -54,14 +54,14 @@ class NestedKeysTests: XCTestCase {
 				"string": "String!",
 
 				"nested": [
-					"int64Array": [NSNumber(longLong: INT64_MAX), NSNumber(longLong: INT64_MAX - 1), NSNumber(longLong: INT64_MAX - 10)],
+					"int64Array": [NSNumber(value: INT64_MAX), NSNumber(value: INT64_MAX - 1), NSNumber(value: INT64_MAX - 10)],
 					"boolArray": [false, true, false],
 					"intArray": [1, 2, 3],
 					"doubleArray": [1.0, 2.0, 3.0],
 					"floatArray": [1.0 as Float, 2.0 as Float, 3.0 as Float],
 					"stringArray": ["123", "ABC"],
 
-					"int64Dict": ["1": NSNumber(longLong: INT64_MAX)],
+					"int64Dict": ["1": NSNumber(value: INT64_MAX)],
 					"boolDict": ["2": true],
 					"intDict": ["3": 999],
 					"doubleDict": ["4": 999.999],
@@ -167,7 +167,7 @@ class NestedKeys: Mappable {
 		
 	}
 
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		nonNestedString <- map["non.nested.key", nested: false]
 		
 		int64	<- map["nested.int64"]
@@ -210,7 +210,7 @@ class Object: Mappable, Equatable {
 		
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		value <- map["value"]
 	}
 }
@@ -220,23 +220,23 @@ func == (lhs: Object, rhs: Object) -> Bool {
 }
 
 enum Int64Enum: NSNumber {
-	case A = 0
-	case B = 1000
+	case a = 0
+	case b = 1000
 }
 
 enum IntEnum: Int {
-	case A = 0
-	case B = 255
+	case a = 0
+	case b = 255
 }
 
 enum DoubleEnum: Double {
-	case A = 0.0
-	case B = 100.0
+	case a = 0.0
+	case b = 100.0
 }
 
 enum FloatEnum: Float {
-	case A = 0.0
-	case B = 100.0
+	case a = 0.0
+	case b = 100.0
 }
 
 enum StringEnum: String {

--- a/ObjectMapperTests/NullableKeysFromJSONTests.swift
+++ b/ObjectMapperTests/NullableKeysFromJSONTests.swift
@@ -53,7 +53,7 @@ class NullableKeysFromJSONTests: XCTestCase {
 		XCTAssertNotNil(player.age)
 		XCTAssertNotNil(player.address?.city)
 
-		mapper.map(nullJSONString, toObject: player)
+		_ = mapper.map(nullJSONString, toObject: player)
 
 		XCTAssertNotNil(player.firstName)
 		XCTAssertNil(player.lastName)
@@ -71,7 +71,7 @@ class NullableKeysFromJSONTests: XCTestCase {
 		XCTAssertNotNil(player.age)
 		XCTAssertNotNil(player.address?.city)
 
-		mapper.map(absentJSONString, toObject: player)
+		_ = mapper.map(absentJSONString, toObject: player)
 
 		XCTAssertNotNil(player.firstName)
 		XCTAssertNotNil(player.lastName)
@@ -92,7 +92,7 @@ class Player: Mappable  {
 		mapping(map)
 	}
 
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		firstName <- map["firstName"]
 		lastName <- map["lastName"]
 		team <- map["team"]
@@ -110,7 +110,7 @@ class Address: Mappable {
 		mapping(map)
 	}
 
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		street <- map["street"]
 		number <- map["number"]
 		city <- map["city"]

--- a/ObjectMapperTests/ObjectMapperTests.swift
+++ b/ObjectMapperTests/ObjectMapperTests.swift
@@ -155,7 +155,7 @@ class ObjectMapperTests: XCTestCase {
         
         let json2: [String: AnyObject] = ["username": username, "identifier": identifier, "photoCount": photoCount]
         let user = User()
-        Mapper().map(json2, toObject: user)
+        _ = Mapper().map(json2, toObject: user)
 		
 		XCTAssertEqual(username, user.username)
 		XCTAssertEqual(identifier, user.identifier)
@@ -178,7 +178,7 @@ class ObjectMapperTests: XCTestCase {
 		let user = User()
 		user.username = "Tristan"
 		
-		Mapper().map(JSONString, toObject: user)
+		_ = Mapper().map(JSONString, toObject: user)
 
 		XCTAssertEqual(user.username, username)
 	}
@@ -190,7 +190,7 @@ class ObjectMapperTests: XCTestCase {
 		let user = User()
 		user.username = "Tristan"
 		
-		Mapper().map(JSON, toObject: user)
+		_ = Mapper().map(JSON, toObject: user)
 
 		XCTAssertEqual(username, user.username)
 	}
@@ -202,7 +202,7 @@ class ObjectMapperTests: XCTestCase {
 		let user = User()
 		user.username = "Tristan"
 		
-		Mapper().map(userJSON as AnyObject?, toObject: user)
+		_ = Mapper().map(userJSON as AnyObject?, toObject: user)
 
 		XCTAssertEqual(user.username, username)
 	}
@@ -354,9 +354,9 @@ class ObjectMapperTests: XCTestCase {
 	}
 	
 	func testArrayOfEnumObjects(){
-		let a: ExampleEnum = .A
-		let b: ExampleEnum = .B
-		let c: ExampleEnum = .C
+		let a: ExampleEnum = .a
+		let b: ExampleEnum = .b
+		let c: ExampleEnum = .c
 
 		let JSONString = "{ \"enums\": [\(a.rawValue), \(b.rawValue), \(c.rawValue)] }"
 
@@ -384,9 +384,9 @@ class ObjectMapperTests: XCTestCase {
 	}
 
 	func testDictionryOfEnumObjects(){
-		let a: ExampleEnum = .A
-		let b: ExampleEnum = .B
-		let c: ExampleEnum = .C
+		let a: ExampleEnum = .a
+		let b: ExampleEnum = .b
+		let c: ExampleEnum = .c
 
 		let JSONString = "{ \"enums\": {\"A\": \(a.rawValue), \"B\": \(b.rawValue), \"C\": \(c.rawValue)} }"
 
@@ -545,13 +545,13 @@ class ObjectMapperTests: XCTestCase {
 			"bigList": [["name": "item 1"], ["name": "item 2"], ["name": "item 3"]]
 		]
 		let model = CachedModel()
-		Mapper().map(json, toObject: model)
+		_ = Mapper().map(json, toObject: model)
 
 		XCTAssertEqual(model.name, "Entry 1")
 		XCTAssertEqual(model.bigList?.count, 3)
 
 		let json2: [String: AnyObject] = ["name": "Entry 1"]
-		Mapper().map(json2, toObject: model)
+		_ = Mapper().map(json2, toObject: model)
 
 		XCTAssertEqual(model.name, "Entry 1")
 		XCTAssertEqual(model.bigList?.count, 3)
@@ -565,7 +565,7 @@ class Response<T: Mappable>: Mappable {
 		
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		result <- map["result"]
 	}
 }
@@ -577,7 +577,7 @@ class Status: Mappable {
 		
 	}
 
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		status <- map["code"]
 	}
 }
@@ -590,7 +590,7 @@ class Plan: Mappable {
 		
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		tasks <- map["tasks"]
 		dictionaryOfTasks <- map["dictionaryOfTasks"]
 	}
@@ -608,7 +608,7 @@ class Task: Mappable {
 		
 	}
 
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		taskId <- map["taskId"]
 		percentage <- map["percentage"]
 	}
@@ -622,7 +622,7 @@ class TaskDictionary: Mappable {
 		
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		test <- map["test"]
 		tasks <- map["tasks"]
 	}
@@ -644,7 +644,7 @@ struct Student: Mappable {
 		
 	}
 
-	mutating func mapping(map: Map) {
+	mutating func mapping(_ map: Map) {
 		name <- map["name"]
 		UUID <- map["UUID"]
 		major <- map["major"]
@@ -685,7 +685,7 @@ class User: Mappable {
 		
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		username         <- map["username"]
 		identifier       <- map["identifier"]
 		photoCount       <- map["photoCount"]
@@ -718,7 +718,7 @@ class Base: Mappable {
 		
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		base <- map["base"]
 	}
 }
@@ -735,7 +735,7 @@ class Subclass: Base {
 		super.init(map)
 	}
 
-	override func mapping(map: Map) {
+	override func mapping(_ map: Map) {
 		super.mapping(map)
 		
 		sub <- map["sub"]
@@ -755,7 +755,7 @@ class GenericSubclass<T>: Base {
 		super.init(map)
 	}
 
-	override func mapping(map: Map) {
+	override func mapping(_ map: Map) {
 		super.mapping(map)
 		
 		sub <- map["sub"]
@@ -769,7 +769,7 @@ class WithGenericArray<T: Mappable>: Mappable {
 		
 	}
 
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		genericItems <- map["genericItems"]
 	}
 }
@@ -781,7 +781,7 @@ class ConcreteItem: Mappable {
 		
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		value <- map["value"]
 	}
 }
@@ -793,9 +793,9 @@ class SubclassWithGenericArrayInSuperclass<Unused>: WithGenericArray<ConcreteIte
 }
 
 enum ExampleEnum: Int {
-	case A
-	case B
-	case C
+	case a
+	case b
+	case c
 }
 
 class ExampleEnumArray: Mappable {
@@ -805,7 +805,7 @@ class ExampleEnumArray: Mappable {
 		
 	}
 
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		enums <- map["enums"]
 	}
 }
@@ -817,7 +817,7 @@ class ExampleEnumDictionary: Mappable {
 		
 	}
 
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		enums <- map["enums"]
 	}
 }
@@ -828,7 +828,7 @@ class ArrayTest: Mappable {
 	
 	required init?(_ map: Map){}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		twoDimensionalArray <- map["twoDimensionalArray"]
 	}
 }
@@ -841,7 +841,7 @@ class CachedModel: Mappable {
 
 	required init?(_ map: Map){}
 
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		name <- map["name"]
 		bigList <- map["bigList"]
 	}
@@ -852,7 +852,7 @@ struct CachedItem: Mappable {
 
 	init?(_ map: Map){}
 
-	mutating func mapping(map: Map) {
+	mutating func mapping(_ map: Map) {
 		name <- map["name"]
 	}
 }
@@ -876,14 +876,14 @@ extension Immutable: Mappable {
 		}
 	}
 		
-	mutating func mapping(map: Map) {
+	mutating func mapping(_ map: Map) {
 		switch map.mappingType {
-		case .FromJSON:
+		case .fromJSON:
 			if let x = Immutable(map) {
 				self = x
 			}
 			
-		case .ToJSON:
+		case .tojson:
 			var prop1 = self.prop1
 			var prop2 = self.prop2
 			var prop3 = self.prop3

--- a/ObjectMapperTests/PerformanceTests.swift
+++ b/ObjectMapperTests/PerformanceTests.swift
@@ -22,7 +22,7 @@ class PerformanceTests: XCTestCase {
         super.tearDown()
     }
 	
-	func createJSONString(count: Int = 1000) -> String {
+	func createJSONString(_ count: Int = 1000) -> String {
 		let subPersonJSON = "{\"identifier\" : \"user8723\", \"drinker\" : true, \"age\": 17, \"username\" : \"sub user\" }"
 		
 		let personJSONString = "{\"username\":\"John Doe\",\"identifier\":\"identifier\",\"photoCount\":12,\"age\":1227,\"drinker\":true,\"smoker\":false, \"arr\":[ \"bla\", true, 42 ], \"dict\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"arrOpt\":[ \"bla\", true, 42 ], \"dictOpt\":{ \"key1\" : \"value1\", \"key2\" : false, \"key3\" : 142 }, \"weight\": 122.22, \"float\": 123.331, \"friend\": \(subPersonJSON), \"friendDictionary\":{ \"bestFriend\": \(subPersonJSON)}}"
@@ -38,18 +38,18 @@ class PerformanceTests: XCTestCase {
     func testPerformance() {
         let JSONString = createJSONString()
 		
-        self.measureBlock {
+        self.measure {
             // Put the code you want to measure the time of here.
-			Mapper<Person>().mapArray(JSONString)
+			_ = Mapper<Person>().mapArray(JSONString)
         }
     }
 	
 	func testPerformanceCluster() {
 		let JSONString = createJSONString()
 		
-		self.measureBlock {
+		self.measure {
 			// Put the code you want to measure the time of here.
-			Mapper<PersonCluster>().mapArray(JSONString)
+			_ = Mapper<PersonCluster>().mapArray(JSONString)
 		}
 	}
 }
@@ -81,7 +81,7 @@ class Person: Mappable {
 		
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		username         <- map["username"]
 		identifier       <- map["identifier"]
 		photoCount       <- map["photoCount"]
@@ -128,11 +128,11 @@ class PersonCluster: Mappable {
 		
 	}
 	
-	static func objectForMapping(map: Map) -> Mappable? {
+	static func objectForMapping(_ map: Map) -> Mappable? {
 		return PersonCluster()
 	}
 	
-	func mapping(map: Map) {
+	func mapping(_ map: Map) {
 		username         <- map["username"]
 		identifier       <- map["identifier"]
 		photoCount       <- map["photoCount"]

--- a/ObjectMapperTests/ToObjectTests.swift
+++ b/ObjectMapperTests/ToObjectTests.swift
@@ -67,7 +67,7 @@ class ToObjectTests: XCTestCase {
 		XCTAssertNotNil(initialChild)
 		XCTAssertEqual(initialChild?.name, initialChildName)
 		
-		Mapper<Person>().map(updatedJSONString, toObject: mappedObject!)
+		_ = Mapper<Person>().map(updatedJSONString, toObject: mappedObject!)
 		
 		let updatedChild = mappedObject?.children?[childKey]
 		XCTAssert(initialChild === updatedChild, "Expected mapping to update the existing object not create a new one")
@@ -84,7 +84,7 @@ class ToObjectTests: XCTestCase {
 			
 		}
 		
-		func mapping(map: Map) {
+		func mapping(_ map: Map) {
 			name		<- map["name"]
 			spouse		<- map["spouse"]
 			children	<- map["children"]


### PR DESCRIPTION
Migrated the project to Swift 3.0. Do not merge this one before Xcode 8 is finally released. To use it in the meanwhile use the following pod: 
`pod 'ObjectMapper', :git=> 'git@github.com:e-Sixt/ObjectMapper.git', :branch => 'master'`