### PR TITLE
Resort to a separate protocol for failable initializer

### DIFF
--- a/ObjectMapper/Core/FromJSON.swift
+++ b/ObjectMapper/Core/FromJSON.swift
@@ -46,7 +46,7 @@ internal final class FromJSON {
 	}
 	
 	/// Mappable object
-	class func object<N: Mappable>(inout field: N, map: Map) {
+	class func object<N: BaseMappable>(inout field: N, map: Map) {
 		if map.toObject {
 			Mapper(context: map.context).map(map.currentValue, toObject: field)
 		} else if let value: N = Mapper(context: map.context).map(map.currentValue) {
@@ -55,7 +55,7 @@ internal final class FromJSON {
 	}
 	
 	/// Optional Mappable Object
-	class func optionalObject<N: Mappable>(inout field: N?, map: Map) {
+	class func optionalObject<N: BaseMappable>(inout field: N?, map: Map) {
 		if let field = field where map.toObject && map.currentValue != nil {
 			Mapper(context: map.context).map(map.currentValue, toObject: field)
 		} else {
@@ -64,7 +64,7 @@ internal final class FromJSON {
 	}
 	
 	/// Implicitly unwrapped Optional Mappable Object
-	class func optionalObject<N: Mappable>(inout field: N!, map: Map) {
+	class func optionalObject<N: BaseMappable>(inout field: N!, map: Map) {
 		if let field = field where map.toObject && map.currentValue != nil {
 			Mapper(context: map.context).map(map.currentValue, toObject: field)
 		} else {
@@ -73,14 +73,14 @@ internal final class FromJSON {
 	}
 	
 	/// mappable object array
-	class func objectArray<N: Mappable>(inout field: Array<N>, map: Map) {
+	class func objectArray<N: BaseMappable>(inout field: Array<N>, map: Map) {
 		if let objects = Mapper<N>(context: map.context).mapArray(map.currentValue) {
 			field = objects
 		}
 	}
 	
 	/// optional mappable object array
-	class func optionalObjectArray<N: Mappable>(inout field: Array<N>?, map: Map) {
+	class func optionalObjectArray<N: BaseMappable>(inout field: Array<N>?, map: Map) {
 		if let objects: Array<N> = Mapper(context: map.context).mapArray(map.currentValue) {
 			field = objects
 		} else {
@@ -89,7 +89,7 @@ internal final class FromJSON {
 	}
 	
 	/// Implicitly unwrapped optional mappable object array
-	class func optionalObjectArray<N: Mappable>(inout field: Array<N>!, map: Map) {
+	class func optionalObjectArray<N: BaseMappable>(inout field: Array<N>!, map: Map) {
 		if let objects: Array<N> = Mapper(context: map.context).mapArray(map.currentValue) {
 			field = objects
 		} else {
@@ -98,24 +98,24 @@ internal final class FromJSON {
 	}
 	
 	/// mappable object array
-	class func twoDimensionalObjectArray<N: Mappable>(inout field: Array<Array<N>>, map: Map) {
+	class func twoDimensionalObjectArray<N: BaseMappable>(inout field: Array<Array<N>>, map: Map) {
 		if let objects = Mapper<N>(context: map.context).mapArrayOfArrays(map.currentValue) {
 			field = objects
 		}
 	}
 	
 	/// optional mappable 2 dimentional object array
-	class func optionalTwoDimensionalObjectArray<N: Mappable>(inout field: Array<Array<N>>?, map: Map) {
+	class func optionalTwoDimensionalObjectArray<N: BaseMappable>(inout field: Array<Array<N>>?, map: Map) {
 		field = Mapper(context: map.context).mapArrayOfArrays(map.currentValue)
 	}
 	
 	/// Implicitly unwrapped optional 2 dimentional mappable object array
-	class func optionalTwoDimensionalObjectArray<N: Mappable>(inout field: Array<Array<N>>!, map: Map) {
+	class func optionalTwoDimensionalObjectArray<N: BaseMappable>(inout field: Array<Array<N>>!, map: Map) {
 		field = Mapper(context: map.context).mapArrayOfArrays(map.currentValue)
 	}
 	
 	/// Dctionary containing Mappable objects
-	class func objectDictionary<N: Mappable>(inout field: Dictionary<String, N>, map: Map) {
+	class func objectDictionary<N: BaseMappable>(inout field: Dictionary<String, N>, map: Map) {
 		if map.toObject {
 			Mapper<N>(context: map.context).mapDictionary(map.currentValue, toDictionary: field)
 		} else {
@@ -126,7 +126,7 @@ internal final class FromJSON {
 	}
 	
 	/// Optional dictionary containing Mappable objects
-	class func optionalObjectDictionary<N: Mappable>(inout field: Dictionary<String, N>?, map: Map) {
+	class func optionalObjectDictionary<N: BaseMappable>(inout field: Dictionary<String, N>?, map: Map) {
 		if let field = field where map.toObject && map.currentValue != nil {
 			Mapper(context: map.context).mapDictionary(map.currentValue, toDictionary: field)
 		} else {
@@ -135,7 +135,7 @@ internal final class FromJSON {
 	}
 	
 	/// Implicitly unwrapped Dictionary containing Mappable objects
-	class func optionalObjectDictionary<N: Mappable>(inout field: Dictionary<String, N>!, map: Map) {
+	class func optionalObjectDictionary<N: BaseMappable>(inout field: Dictionary<String, N>!, map: Map) {
 		if let field = field where map.toObject && map.currentValue != nil {
 			Mapper(context: map.context).mapDictionary(map.currentValue, toDictionary: field)
 		} else {
@@ -144,36 +144,36 @@ internal final class FromJSON {
 	}
 	
 	/// Dictionary containing Array of Mappable objects
-	class func objectDictionaryOfArrays<N: Mappable>(inout field: Dictionary<String, [N]>, map: Map) {
+	class func objectDictionaryOfArrays<N: BaseMappable>(inout field: Dictionary<String, [N]>, map: Map) {
 		if let objects = Mapper<N>(context: map.context).mapDictionaryOfArrays(map.currentValue) {
 			field = objects
 		}
 	}
 	
 	/// Optional Dictionary containing Array of Mappable objects
-	class func optionalObjectDictionaryOfArrays<N: Mappable>(inout field: Dictionary<String, [N]>?, map: Map) {
+	class func optionalObjectDictionaryOfArrays<N: BaseMappable>(inout field: Dictionary<String, [N]>?, map: Map) {
 		field = Mapper<N>(context: map.context).mapDictionaryOfArrays(map.currentValue)
 	}
 	
 	/// Implicitly unwrapped Dictionary containing Array of Mappable objects
-	class func optionalObjectDictionaryOfArrays<N: Mappable>(inout field: Dictionary<String, [N]>!, map: Map) {
+	class func optionalObjectDictionaryOfArrays<N: BaseMappable>(inout field: Dictionary<String, [N]>!, map: Map) {
 		field = Mapper<N>(context: map.context).mapDictionaryOfArrays(map.currentValue)
 	}
 	
 	/// mappable object Set
-	class func objectSet<N: Mappable>(inout field: Set<N>, map: Map) {
+	class func objectSet<N: BaseMappable>(inout field: Set<N>, map: Map) {
 		if let objects = Mapper<N>(context: map.context).mapSet(map.currentValue) {
 			field = objects
 		}
 	}
 	
 	/// optional mappable object array
-	class func optionalObjectSet<N: Mappable>(inout field: Set<N>?, map: Map) {
+	class func optionalObjectSet<N: BaseMappable>(inout field: Set<N>?, map: Map) {
 		field = Mapper(context: map.context).mapSet(map.currentValue)
 	}
 	
 	/// Implicitly unwrapped optional mappable object array
-	class func optionalObjectSet<N: Mappable>(inout field: Set<N>!, map: Map) {
+	class func optionalObjectSet<N: BaseMappable>(inout field: Set<N>!, map: Map) {
 		field = Mapper(context: map.context).mapSet(map.currentValue)
 	}
 	

--- a/ObjectMapper/Core/Mappable.swift
+++ b/ObjectMapper/Core/Mappable.swift
@@ -8,17 +8,17 @@
 
 import Foundation
 
-public protocol Mappable {
+public protocol BaseMappable {
 	/// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
 	mutating func mapping(map: Map)
 }
 
-public protocol CreateMappable: Mappable {
+public protocol Mappable: BaseMappable {
 	/// This function can be used to validate JSON prior to mapping. Return nil to cancel mapping at this point
 	init?(_ map: Map)
 }
 
-public protocol StaticMappable: Mappable {
+public protocol StaticMappable: BaseMappable {
 	/// This is function that can be used to:
 	///		1) provide an existing cached object to be used for mapping
 	///		2) return an object of another class (which conforms to Mappable) to be used for mapping. For instance, you may inspect the JSON to infer the type of object that should be used for any given mapping

--- a/ObjectMapper/Core/Mappable.swift
+++ b/ObjectMapper/Core/Mappable.swift
@@ -9,10 +9,13 @@
 import Foundation
 
 public protocol Mappable {
-	/// This function can be used to validate JSON prior to mapping. Return nil to cancel mapping at this point
-	init?(_ map: Map)
 	/// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
 	mutating func mapping(map: Map)
+}
+
+public protocol CreateMappable: Mappable {
+	/// This function can be used to validate JSON prior to mapping. Return nil to cancel mapping at this point
+	init?(_ map: Map)
 }
 
 public protocol StaticMappable: Mappable {

--- a/ObjectMapper/Core/Mappable.swift
+++ b/ObjectMapper/Core/Mappable.swift
@@ -14,18 +14,18 @@ public protocol BaseMappable {
 }
 
 public protocol Mappable: BaseMappable {
-	/// This function can be used to validate JSON prior to mapping. Return nil to cancel mapping at this point
-	init?(_ map: Map)
+    /// This function can be used to validate JSON prior to mapping. Return nil to cancel mapping at this point
+    init?(_ map: Map)
 }
 
 public protocol StaticMappable: BaseMappable {
 	/// This is function that can be used to:
 	///		1) provide an existing cached object to be used for mapping
 	///		2) return an object of another class (which conforms to Mappable) to be used for mapping. For instance, you may inspect the JSON to infer the type of object that should be used for any given mapping
-	static func objectForMapping(map: Map) -> Mappable?
+	static func objectForMapping(map: Map) -> BaseMappable?
 }
 
-public extension Mappable {
+public extension BaseMappable {
 	
 	/// Initializes object from a JSON String
 	public init?(JSONString: String) {
@@ -56,7 +56,7 @@ public extension Mappable {
 	}
 }
 
-public extension Array where Element: Mappable {
+public extension Array where Element: BaseMappable {
 	
 	/// Initialize Array from a JSON String
 	public init?(JSONString: String) {
@@ -87,7 +87,7 @@ public extension Array where Element: Mappable {
 	}
 }
 
-public extension Set where Element: Mappable {
+public extension Set where Element: BaseMappable {
 	
 	/// Initializes a set from a JSON String
 	public init?(JSONString: String) {

--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -117,11 +117,13 @@ public final class Mapper<N: Mappable> {
 		}
 		
 		// fall back to using init? to create N
-		if var object = N(map) {
-			object.mapping(map)
-			return object
+		if let klass = N.self as? CreateMappable.Type {
+			if var object = klass.init(map) as? N {
+				object.mapping(map)
+				return object
+			}
 		}
-		
+
 		return nil
 	}
 

--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -34,7 +34,7 @@ public enum MappingType {
 }
 
 /// The Mapper class provides methods for converting Model objects to JSON and methods for converting JSON to Model objects
-public final class Mapper<N: Mappable> {
+public final class Mapper<N: BaseMappable> {
 	
 	public var context: MapContext?
 	
@@ -115,7 +115,7 @@ public final class Mapper<N: Mappable> {
 				return object
 			}
 		}
-		
+
 		// fall back to using init? to create N
 		if let klass = N.self as? Mappable.Type {
 			if var object = klass.init(map) as? N {

--- a/ObjectMapper/Core/Mapper.swift
+++ b/ObjectMapper/Core/Mapper.swift
@@ -117,7 +117,7 @@ public final class Mapper<N: Mappable> {
 		}
 		
 		// fall back to using init? to create N
-		if let klass = N.self as? CreateMappable.Type {
+		if let klass = N.self as? Mappable.Type {
 			if var object = klass.init(map) as? N {
 				object.mapping(map)
 				return object

--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -280,10 +280,10 @@ private func toJSONDictionaryWithTransform<Transform: TransformType>(input: [Str
 	}
 }
 
-// MARK:- Mappable Objects - <T: Mappable>
+// MARK:- Mappable Objects - <T: BaseMappable>
 
 /// Object conforming to Mappable
-public func <- <T: Mappable>(inout left: T, right: Map) {
+public func <- <T: BaseMappable>(inout left: T, right: Map) {
 	switch right.mappingType {
 	case .FromJSON:
 		FromJSON.object(&left, map: right)
@@ -293,7 +293,7 @@ public func <- <T: Mappable>(inout left: T, right: Map) {
 }
 
 /// Optional Mappable objects
-public func <- <T: Mappable>(inout left: T?, right: Map) {
+public func <- <T: BaseMappable>(inout left: T?, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalObject(&left, map: right)
@@ -304,7 +304,7 @@ public func <- <T: Mappable>(inout left: T?, right: Map) {
 }
 
 /// Implicitly unwrapped optional Mappable objects
-public func <- <T: Mappable>(inout left: T!, right: Map) {
+public func <- <T: BaseMappable>(inout left: T!, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalObject(&left, map: right)
@@ -314,10 +314,10 @@ public func <- <T: Mappable>(inout left: T!, right: Map) {
 	}
 }
 
-// MARK:- Transforms of Mappable Objects - <T: Mappable>
+// MARK:- Transforms of Mappable Objects - <T: BaseMappable>
 
 /// Object conforming to Mappable that have transforms
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Transform.Object, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Transform.Object, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
 	case .FromJSON where map.isKeyPresent:
@@ -331,7 +331,7 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Optional Mappable objects that have transforms
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Transform.Object?, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Transform.Object?, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
 	case .FromJSON where map.isKeyPresent:
@@ -345,7 +345,7 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Implicitly unwrapped optional Mappable objects that have transforms
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Transform.Object!, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Transform.Object!, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
 	case .FromJSON where map.isKeyPresent:
@@ -358,10 +358,10 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 	}
 }
 
-// MARK:- Dictionary of Mappable objects - Dictionary<String, T: Mappable>
+// MARK:- Dictionary of Mappable objects - Dictionary<String, T: BaseMappable>
 
-/// Dictionary of Mappable objects <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, T>, right: Map) {
+/// Dictionary of Mappable objects <String, T: BaseMappable>
+public func <- <T: BaseMappable>(inout left: Dictionary<String, T>, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.objectDictionary(&left, map: right)
@@ -371,8 +371,8 @@ public func <- <T: Mappable>(inout left: Dictionary<String, T>, right: Map) {
 	}
 }
 
-/// Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, T>?, right: Map) {
+/// Optional Dictionary of Mappable object <String, T: BaseMappable>
+public func <- <T: BaseMappable>(inout left: Dictionary<String, T>?, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectDictionary(&left, map: right)
@@ -382,8 +382,8 @@ public func <- <T: Mappable>(inout left: Dictionary<String, T>?, right: Map) {
 	}
 }
 
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, T>!, right: Map) {
+/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: BaseMappable>
+public func <- <T: BaseMappable>(inout left: Dictionary<String, T>!, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectDictionary(&left, map: right)
@@ -393,8 +393,8 @@ public func <- <T: Mappable>(inout left: Dictionary<String, T>!, right: Map) {
 	}
 }
 
-/// Dictionary of Mappable objects <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, [T]>, right: Map) {
+/// Dictionary of Mappable objects <String, T: BaseMappable>
+public func <- <T: BaseMappable>(inout left: Dictionary<String, [T]>, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.objectDictionaryOfArrays(&left, map: right)
@@ -404,8 +404,8 @@ public func <- <T: Mappable>(inout left: Dictionary<String, [T]>, right: Map) {
 	}
 }
 
-/// Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, [T]>?, right: Map) {
+/// Optional Dictionary of Mappable object <String, T: BaseMappable>
+public func <- <T: BaseMappable>(inout left: Dictionary<String, [T]>?, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectDictionaryOfArrays(&left, map: right)
@@ -415,8 +415,8 @@ public func <- <T: Mappable>(inout left: Dictionary<String, [T]>?, right: Map) {
 	}
 }
 
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: Mappable>(inout left: Dictionary<String, [T]>!, right: Map) {
+/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: BaseMappable>
+public func <- <T: BaseMappable>(inout left: Dictionary<String, [T]>!, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectDictionaryOfArrays(&left, map: right)
@@ -426,10 +426,10 @@ public func <- <T: Mappable>(inout left: Dictionary<String, [T]>!, right: Map) {
 	}
 }
 
-// MARK:- Dictionary of Mappable objects with a transform - Dictionary<String, T: Mappable>
+// MARK:- Dictionary of Mappable objects with a transform - Dictionary<String, T: BaseMappable>
 
-/// Dictionary of Mappable objects <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, Transform.Object>, right: (Map, Transform)) {
+/// Dictionary of Mappable objects <String, T: BaseMappable> with a transform
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Dictionary<String, Transform.Object>, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let object = map.currentValue as? [String : AnyObject] where map.mappingType == .FromJSON && map.isKeyPresent {
 		let value = fromJSONDictionaryWithTransform(object, transform: transform) ?? left
@@ -440,8 +440,8 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 	}
 }
 
-/// Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, Transform.Object>?, right: (Map, Transform)) {
+/// Optional Dictionary of Mappable object <String, T: BaseMappable> with a transform
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Dictionary<String, Transform.Object>?, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let object = map.currentValue as? [String : AnyObject] where map.mappingType == .FromJSON && map.isKeyPresent {
 		let value = fromJSONDictionaryWithTransform(object, transform: transform) ?? left
@@ -452,8 +452,8 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 	}
 }
 
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, Transform.Object>!, right: (Map, Transform)) {
+/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: BaseMappable> with a transform
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Dictionary<String, Transform.Object>!, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let dictionary = map.currentValue as? [String : AnyObject] where map.mappingType == .FromJSON && map.isKeyPresent {
 		let transformedDictionary = fromJSONDictionaryWithTransform(dictionary, transform: transform) ?? left
@@ -464,8 +464,8 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 	}
 }
 
-/// Dictionary of Mappable objects <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, [Transform.Object]>, right: (Map, Transform)) {
+/// Dictionary of Mappable objects <String, T: BaseMappable> with a transform
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Dictionary<String, [Transform.Object]>, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
 		let transformedDictionary = dictionary.map { (key, values) in
@@ -481,8 +481,8 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 	}
 }
 
-/// Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, [Transform.Object]>?, right: (Map, Transform)) {
+/// Optional Dictionary of Mappable object <String, T: BaseMappable> with a transform
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Dictionary<String, [Transform.Object]>?, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
 		let transformedDictionary = dictionary.map { (key, values) in
@@ -498,8 +498,8 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 	}
 }
 
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, [Transform.Object]>!, right: (Map, Transform)) {
+/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: BaseMappable> with a transform
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Dictionary<String, [Transform.Object]>!, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
 		let transformedDictionary = dictionary.map { (key, values) in
@@ -515,10 +515,10 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 	}
 }
 
-// MARK:- Array of Mappable objects - Array<T: Mappable>
+// MARK:- Array of Mappable objects - Array<T: BaseMappable>
 
 /// Array of Mappable objects
-public func <- <T: Mappable>(inout left: Array<T>, right: Map) {
+public func <- <T: BaseMappable>(inout left: Array<T>, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.objectArray(&left, map: right)
@@ -529,7 +529,7 @@ public func <- <T: Mappable>(inout left: Array<T>, right: Map) {
 }
 
 /// Optional array of Mappable objects
-public func <- <T: Mappable>(inout left: Array<T>?, right: Map) {
+public func <- <T: BaseMappable>(inout left: Array<T>?, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectArray(&left, map: right)
@@ -540,7 +540,7 @@ public func <- <T: Mappable>(inout left: Array<T>?, right: Map) {
 }
 
 /// Implicitly unwrapped Optional array of Mappable objects
-public func <- <T: Mappable>(inout left: Array<T>!, right: Map) {
+public func <- <T: BaseMappable>(inout left: Array<T>!, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectArray(&left, map: right)
@@ -550,10 +550,10 @@ public func <- <T: Mappable>(inout left: Array<T>!, right: Map) {
 	}
 }
 
-// MARK:- Array of Mappable objects with transforms - Array<T: Mappable>
+// MARK:- Array of Mappable objects with transforms - Array<T: BaseMappable>
 
 /// Array of Mappable objects
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Array<Transform.Object>, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Array<Transform.Object>, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
 	case .FromJSON where map.isKeyPresent:
@@ -568,7 +568,7 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Optional array of Mappable objects
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Array<Transform.Object>?, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Array<Transform.Object>?, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
 	case .FromJSON where map.isKeyPresent:
@@ -582,7 +582,7 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Implicitly unwrapped Optional array of Mappable objects
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Array<Transform.Object>!, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Array<Transform.Object>!, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
 	case .FromJSON where map.isKeyPresent:
@@ -595,10 +595,10 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 	}
 }
 
-// MARK:- Array of Array of Mappable objects - Array<Array<T: Mappable>>
+// MARK:- Array of Array of Mappable objects - Array<Array<T: BaseMappable>>
 
 /// Array of Array Mappable objects
-public func <- <T: Mappable>(inout left: Array<Array<T>>, right: Map) {
+public func <- <T: BaseMappable>(inout left: Array<Array<T>>, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.twoDimensionalObjectArray(&left, map: right)
@@ -609,7 +609,7 @@ public func <- <T: Mappable>(inout left: Array<Array<T>>, right: Map) {
 }
 
 /// Optional array of Mappable objects
-public func <- <T: Mappable>(inout left:Array<Array<T>>?, right: Map) {
+public func <- <T: BaseMappable>(inout left:Array<Array<T>>?, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalTwoDimensionalObjectArray(&left, map: right)
@@ -620,7 +620,7 @@ public func <- <T: Mappable>(inout left:Array<Array<T>>?, right: Map) {
 }
 
 /// Implicitly unwrapped Optional array of Mappable objects
-public func <- <T: Mappable>(inout left: Array<Array<T>>!, right: Map) {
+public func <- <T: BaseMappable>(inout left: Array<Array<T>>!, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalTwoDimensionalObjectArray(&left, map: right)
@@ -630,10 +630,10 @@ public func <- <T: Mappable>(inout left: Array<Array<T>>!, right: Map) {
 	}
 }
 
-// MARK:- Array of Array of Mappable objects - Array<Array<T: Mappable>> with transforms
+// MARK:- Array of Array of Mappable objects - Array<Array<T: BaseMappable>> with transforms
 
 /// Array of Array Mappable objects with transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Array<Array<Transform.Object>>, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Array<Array<Transform.Object>>, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let original2DArray = map.currentValue as? [[AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
 		let transformed2DArray = original2DArray.flatMap { values in
@@ -649,7 +649,7 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Optional array of Mappable objects with transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left:Array<Array<Transform.Object>>?, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left:Array<Array<Transform.Object>>?, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let original2DArray = map.currentValue as? [[AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
 		let transformed2DArray = original2DArray.flatMap { values in
@@ -665,7 +665,7 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 }
 
 /// Implicitly unwrapped Optional array of Mappable objects with transform
-public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Array<Array<Transform.Object>>!, right: (Map, Transform)) {
+public func <- <Transform: TransformType where Transform.Object: BaseMappable>(inout left: Array<Array<Transform.Object>>!, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let original2DArray = map.currentValue as? [[AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
 		let transformed2DArray = original2DArray.flatMap { values in
@@ -680,10 +680,10 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 	}
 }
 
-// MARK:- Set of Mappable objects - Set<T: Mappable where T: Hashable>
+// MARK:- Set of Mappable objects - Set<T: BaseMappable where T: Hashable>
 
 /// Set of Mappable objects
-public func <- <T: Mappable where T: Hashable>(inout left: Set<T>, right: Map) {
+public func <- <T: BaseMappable where T: Hashable>(inout left: Set<T>, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.objectSet(&left, map: right)
@@ -695,7 +695,7 @@ public func <- <T: Mappable where T: Hashable>(inout left: Set<T>, right: Map) {
 
 
 /// Optional Set of Mappable objects
-public func <- <T: Mappable where T: Hashable>(inout left: Set<T>?, right: Map) {
+public func <- <T: BaseMappable where T: Hashable>(inout left: Set<T>?, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectSet(&left, map: right)
@@ -706,7 +706,7 @@ public func <- <T: Mappable where T: Hashable>(inout left: Set<T>?, right: Map) 
 }
 
 /// Implicitly unwrapped Optional Set of Mappable objects
-public func <- <T: Mappable where T: Hashable>(inout left: Set<T>!, right: Map) {
+public func <- <T: BaseMappable where T: Hashable>(inout left: Set<T>!, right: Map) {
 	switch right.mappingType {
 	case .FromJSON where right.isKeyPresent:
 		FromJSON.optionalObjectSet(&left, map: right)
@@ -717,7 +717,7 @@ public func <- <T: Mappable where T: Hashable>(inout left: Set<T>!, right: Map) 
 }
 
 
-// MARK:- Set of Mappable objects with a transform - Set<T: Mappable where T: Hashable>
+// MARK:- Set of Mappable objects with a transform - Set<T: BaseMappable where T: Hashable>
 
 /// Set of Mappable objects with transform
 public func <- <Transform: TransformType where Transform.Object: protocol<Hashable, Mappable>>(inout left: Set<Transform.Object>, right: (Map, Transform)) {

--- a/ObjectMapper/Core/ToJSON.swift
+++ b/ObjectMapper/Core/ToJSON.swift
@@ -99,29 +99,29 @@ internal final class ToJSON {
 		}
 	}
 
-	class func object<N: Mappable>(field: N, map: Map) {
+	class func object<N: BaseMappable>(field: N, map: Map) {
 		setValue(Mapper(context: map.context).toJSON(field), map: map)
 	}
 	
-	class func optionalObject<N: Mappable>(field: N?, map: Map) {
+	class func optionalObject<N: BaseMappable>(field: N?, map: Map) {
 		if let field = field {
 			object(field, map: map)
 		}
 	}
 
-	class func objectArray<N: Mappable>(field: Array<N>, map: Map) {
+	class func objectArray<N: BaseMappable>(field: Array<N>, map: Map) {
 		let JSONObjects = Mapper(context: map.context).toJSONArray(field)
 		
 		setValue(JSONObjects, map: map)
 	}
 	
-	class func optionalObjectArray<N: Mappable>(field: Array<N>?, map: Map) {
+	class func optionalObjectArray<N: BaseMappable>(field: Array<N>?, map: Map) {
 		if let field = field {
 			objectArray(field, map: map)
 		}
 	}
 	
-	class func twoDimensionalObjectArray<N: Mappable>(field: Array<Array<N>>, map: Map) {
+	class func twoDimensionalObjectArray<N: BaseMappable>(field: Array<Array<N>>, map: Map) {
 		var array = [[[String : AnyObject]]]()
 		for innerArray in field {
 			let JSONObjects = Mapper(context: map.context).toJSONArray(innerArray)
@@ -130,43 +130,43 @@ internal final class ToJSON {
 		setValue(array, map: map)
 	}
 	
-	class func optionalTwoDimensionalObjectArray<N: Mappable>(field: Array<Array<N>>?, map: Map) {
+	class func optionalTwoDimensionalObjectArray<N: BaseMappable>(field: Array<Array<N>>?, map: Map) {
 		if let field = field {
 			twoDimensionalObjectArray(field, map: map)
 		}
 	}
 	
-	class func objectSet<N: Mappable where N: Hashable>(field: Set<N>, map: Map) {
+	class func objectSet<N: BaseMappable where N: Hashable>(field: Set<N>, map: Map) {
 		let JSONObjects = Mapper(context: map.context).toJSONSet(field)
 		
 		setValue(JSONObjects, map: map)
 	}
 	
-	class func optionalObjectSet<N: Mappable where N: Hashable>(field: Set<N>?, map: Map) {
+	class func optionalObjectSet<N: BaseMappable where N: Hashable>(field: Set<N>?, map: Map) {
 		if let field = field {
 			objectSet(field, map: map)
 		}
 	}
 	
-	class func objectDictionary<N: Mappable>(field: Dictionary<String, N>, map: Map) {
+	class func objectDictionary<N: BaseMappable>(field: Dictionary<String, N>, map: Map) {
 		let JSONObjects = Mapper(context: map.context).toJSONDictionary(field)
 		
 		setValue(JSONObjects, map: map)
 	}
 	
-	class func optionalObjectDictionary<N: Mappable>(field: Dictionary<String, N>?, map: Map) {
+	class func optionalObjectDictionary<N: BaseMappable>(field: Dictionary<String, N>?, map: Map) {
         if let field = field {
 			objectDictionary(field, map: map)
         }
     }
 	
-	class func objectDictionaryOfArrays<N: Mappable>(field: Dictionary<String, [N]>, map: Map) {
+	class func objectDictionaryOfArrays<N: BaseMappable>(field: Dictionary<String, [N]>, map: Map) {
 		let JSONObjects = Mapper(context: map.context).toJSONDictionaryOfArrays(field)
 
 		setValue(JSONObjects, map: map)
 	}
 	
-	class func optionalObjectDictionaryOfArrays<N: Mappable>(field: Dictionary<String, [N]>?, map: Map) {
+	class func optionalObjectDictionaryOfArrays<N: BaseMappable>(field: Dictionary<String, [N]>?, map: Map) {
 		if let field = field {
 			objectDictionaryOfArrays(field, map: map)
 		}


### PR DESCRIPTION
It is effectively impossible to conveniently implement ObjectMapper for NSManagedObject subclasses with the initializer being part of the protocol. So I'm repeating the same trick of separating the part of the protocol with the initializer into a protocol of its own.