### PR TITLE
Update README to reference ObjectMapper+Realm library for ListTransform ✅     

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,12 +305,13 @@ class Model: Object, Mappable {
 }
 ```
 
+If you want to serialize associated RealmObjects, you can use [ObjectMapper+Realm](https://github.com/jakenberg/ObjectMapper-Realm). It is a simple Realm extension that serializes arbitrary JSON into Realm's List class.
+
 Note: Generating a JSON string of a Realm Object using ObjectMappers' `toJSON` function only works within a Realm write transaction. This is caused because ObjectMapper uses the `inout` flag in its mapping functions (`<-`) which are used both for serializing and deserializing. Realm detects the flag and forces the `toJSON` function to be called within a write block even though the objects are not being modified.
 
 # To Do
 - Improve error handling. Perhaps using `throws`
 - Class cluster documentation
-- Realm List Transform
 
 # Contributing
 


### PR DESCRIPTION
### Ahoy Hearst!                                                                                                                                                                                                           

ObjectMapper has been my go-to JSON serialization library for about a year now. I wanted to show my appreciation for your efforts by giving you a hand in checking off a todo for your library.                              
[ObjectMapper+Realm](https://github.com/jakenberg/ObjectMapper-Realm) is an extension to ObjectMapper that serializes JSON data into Realm's List class.                                                                     
I have been battle-testing `ListTransform` in production for about 6 months. Let me know what you think!