### PR TITLE
Compile time improvements

### DIFF
--- a/ObjectMapper/Core/Operators.swift
+++ b/ObjectMapper/Core/Operators.swift
@@ -468,15 +468,21 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, [Transform.Object]>, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
-		let transformedDictionary = dictionary.map { (key, values) in
-			return (key, fromJSONArrayWithTransform(values, transform: transform) ?? left[key] ?? [])
-		}
+		let transformedDictionary = dictionary.map { (key: String, values: [AnyObject]) -> (String, [Transform.Object]) in
+      if let jsonArray = fromJSONArrayWithTransform(values, transform: transform) {
+        return (key, jsonArray)
+      }
+      if let leftValue = left[key] {
+        return (key, leftValue)
+      }
+      return (key, [])
+    }
 		FromJSON.basicType(&left, object: transformedDictionary)
 	} else if map.mappingType == .ToJSON {
 		let transformedDictionary = left.map { (key, values) in
 			return (key, toJSONArrayWithTransform(values, transform: transform) ?? [])
 		}
-		
+
 		ToJSON.basicType(transformedDictionary, map: map)
 	}
 }
@@ -485,15 +491,21 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, [Transform.Object]>?, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
-		let transformedDictionary = dictionary.map { (key, values) in
-			return (key, fromJSONArrayWithTransform(values, transform: transform) ?? left?[key] ?? [])
+		let transformedDictionary = dictionary.map { (key: String, values: [AnyObject]) -> (String, [Transform.Object]) in
+      if let jsonArray = fromJSONArrayWithTransform(values, transform: transform) {
+        return (key, jsonArray)
+      }
+      if let leftValue = left?[key] {
+        return (key, leftValue)
+      }
+      return (key, [])
 		}
 		FromJSON.optionalBasicType(&left, object: transformedDictionary)
 	} else if map.mappingType == .ToJSON {
 		let transformedDictionary = left?.map { (key, values) in
 			return (key, toJSONArrayWithTransform(values, transform: transform) ?? [])
 		}
-		
+
 		ToJSON.optionalBasicType(transformedDictionary, map: map)
 	}
 }
@@ -502,15 +514,21 @@ public func <- <Transform: TransformType where Transform.Object: Mappable>(inout
 public func <- <Transform: TransformType where Transform.Object: Mappable>(inout left: Dictionary<String, [Transform.Object]>!, right: (Map, Transform)) {
 	let (map, transform) = right
 	if let dictionary = map.currentValue as? [String : [AnyObject]] where map.mappingType == .FromJSON && map.isKeyPresent {
-		let transformedDictionary = dictionary.map { (key, values) in
-			return (key, fromJSONArrayWithTransform(values, transform: transform) ?? left?[key] ?? [])
+		let transformedDictionary = dictionary.map { (key: String, values: [AnyObject]) -> (String, [Transform.Object]) in
+      if let jsonArray = fromJSONArrayWithTransform(values, transform: transform) {
+        return (key, jsonArray)
+      }
+      if let leftValue = left?[key] {
+        return (key, leftValue)
+      }
+      return (key, [])
 		}
 		FromJSON.optionalBasicType(&left, object: transformedDictionary)
 	} else if map.mappingType == .ToJSON {
 		let transformedDictionary = left?.map { (key, values) in
 			return (key, toJSONArrayWithTransform(values, transform: transform) ?? [])
 		}
-		
+
 		ToJSON.optionalBasicType(transformedDictionary, map: map)
 	}
 }


### PR DESCRIPTION
ObjectMapper has been taking a lot of time to compile so I added the `-Xfrontend -debug-time-function-bodies` to `OTHER_SWIFT_FLAGS` and discovered the problem.

The Swift compiler seems to be having issues with Type inference and the Nil Coalescing Operator, as such I fixed both and managed to save a lot of time as can be seen in the screenshots below:

Before fix:
<img width="1392" alt="screen shot 2016-08-30 at 16 45 25" src="https://cloud.githubusercontent.com/assets/4968178/18097910/dbab1738-6ed7-11e6-9d0c-02ef937765c7.png">


After fix:
<img width="1392" alt="screen shot 2016-08-30 at 17 36 07" src="https://cloud.githubusercontent.com/assets/4968178/18097997/412554fc-6ed8-11e6-9d01-d1d8191a13c3.png">

I'm sure a lot more stuff can be improved but these cases were the most time demanding ones.

For reference: [Regarding Swift build time optimizations](https://medium.com/@RobertGummesson/regarding-swift-build-time-optimizations-fc92cdd91e31#.9wc64v20a)
