### PR TITLE
Add a flag to disable encoding of strings in URLTransform

### DIFF
--- a/ObjectMapper/Transforms/URLTransform.swift
+++ b/ObjectMapper/Transforms/URLTransform.swift
@@ -31,15 +31,30 @@ import Foundation
 public class URLTransform: TransformType {
 	public typealias Object = NSURL
 	public typealias JSON = String
+	private let shouldEncodeUrlString: Bool
 
-	public init() {}
+	/**
+	Initializes the URLTransform with an option to encode URL strings before converting them to an NSURL
+	- parameter shouldEncodeUrlString: when true (the default) the string is encoded before passing
+	to `NSURL(string:)`
+	- returns: an initialized transformer
+	*/
+	public init(shouldEncodeUrlString: Bool = true) {
+		self.shouldEncodeUrlString = shouldEncodeUrlString
+	}
 
 	public func transformFromJSON(value: AnyObject?) -> NSURL? {
-		if let URLString = value as? String,
-			let escapedURLString = URLString.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet()){
-			return NSURL(string: escapedURLString)
+		guard let URLString = value as? String else { return nil }
+		
+		if !shouldEncodeUrlString {
+			return NSURL(string: URLString)
 		}
-		return nil
+
+		guard let escapedURLString = URLString.stringByAddingPercentEncodingWithAllowedCharacters(
+			NSCharacterSet.URLQueryAllowedCharacterSet()) else {
+			return nil
+		}
+		return NSURL(string: escapedURLString)
 	}
 
 	public func transformToJSON(value: NSURL?) -> String? {

--- a/ObjectMapperTests/CustomTransformTests.swift
+++ b/ObjectMapperTests/CustomTransformTests.swift
@@ -123,6 +123,7 @@ class CustomTransformTests: XCTestCase {
 		let transforms = Transforms()
 		transforms.URL = NSURL(string: "http://google.com/image/1234")!
 		transforms.URLOpt = NSURL(string: "http://google.com/image/1234")
+		transforms.URLWithoutEncoding = NSURL(string: "http://google.com/image/1234#fragment")!
 		
 		let JSON = mapper.toJSON(transforms)
 
@@ -131,6 +132,7 @@ class CustomTransformTests: XCTestCase {
 		XCTAssertNotNil(parsedTransforms)
 		XCTAssertEqual(parsedTransforms?.URL, transforms.URL)
 		XCTAssertEqual(parsedTransforms?.URLOpt, transforms.URLOpt)
+		XCTAssertEqual(parsedTransforms?.URLWithoutEncoding, transforms.URLWithoutEncoding)
 	}
 	
 	func testEnumTransform() {
@@ -161,6 +163,7 @@ class Transforms: Mappable {
 	
 	var URL = NSURL()
 	var URLOpt: NSURL?
+	var URLWithoutEncoding = NSURL()
 	
 	var intWithString: Int = 0
 	
@@ -189,6 +192,7 @@ class Transforms: Mappable {
 
 		URL					<- (map["URL"], URLTransform())
 		URLOpt				<- (map["URLOpt"], URLTransform())
+		URLWithoutEncoding  <- (map["URLWithoutEncoding"], URLTransform(shouldEncodeUrlString: false))
 		
 		intWithString		<- (map["intWithString"], TransformOf<Int, String>(fromJSON: { $0 == nil ? nil : Int($0!) }, toJSON: { $0.map { String($0) } }))
 		int64Value			<- (map["int64Value"], TransformOf<Int64, NSNumber>(fromJSON: { $0?.longLongValue }, toJSON: { $0.map { NSNumber(longLong: $0) } }))


### PR DESCRIPTION
Following up on https://github.com/Hearst-DD/ObjectMapper/issues/497, the encoding of URLs introduced in 9b8163a isn't always desirable. For example, as mentioned in that issue, the string may already be encoded or may contain characters you don't want to be encoded. This is the case with URLs that contain a fragment portion where the `#` character should not be encoded.

This PR adds an optional flag to the`URLTransform` initializer so that the encoding step can be skipped before constructing the `NSURL`.