### PR TITLE
[Immutable] ImmutableMappable

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		030114A91D95187600FBFD4F /* ImmutableMappble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114A81D95187600FBFD4F /* ImmutableMappble.swift */; };
+		030114AC1D951A4F00FBFD4F /* ImmutableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114AA1D95197100FBFD4F /* ImmutableTests.swift */; };
+		030114AD1D951A5300FBFD4F /* ImmutableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114AA1D95197100FBFD4F /* ImmutableTests.swift */; };
+		030114AE1D951A5600FBFD4F /* ImmutableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114AA1D95197100FBFD4F /* ImmutableTests.swift */; };
+		030114AF1D951A6C00FBFD4F /* ImmutableMappble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114A81D95187600FBFD4F /* ImmutableMappble.swift */; };
+		030114B01D951A7100FBFD4F /* ImmutableMappble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114A81D95187600FBFD4F /* ImmutableMappble.swift */; };
+		030114B11D951A7500FBFD4F /* ImmutableMappble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114A81D95187600FBFD4F /* ImmutableMappble.swift */; };
 		37AFD9B91AAD191C00AB59B5 /* CustomDateFormatTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */; };
 		3BAD2C0C1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
 		3BAD2C0D1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
@@ -189,6 +196,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		030114A81D95187600FBFD4F /* ImmutableMappble.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmutableMappble.swift; sourceTree = "<group>"; };
+		030114AA1D95197100FBFD4F /* ImmutableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmutableTests.swift; sourceTree = "<group>"; };
 		37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomDateFormatTransform.swift; sourceTree = "<group>"; };
 		3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Mappable.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MappableExtensionsTests.swift; sourceTree = "<group>"; };
@@ -368,6 +377,7 @@
 				891804CC1C122AF000E5C3EE /* MappableTypesWithTransformsTests.swift */,
 				6A442CA01CE251F100AB4F1F /* MapContextTests.swift */,
 				84D4F8561CC3B71B008B0FB6 /* NSDecimalNumberTransformTests.swift */,
+				030114AA1D95197100FBFD4F /* ImmutableTests.swift */,
 				6AAC8F8319F03C2900E7A677 /* Supporting Files */,
 				6A715C491D05B1FA0054AD62 /* IgnoreNilTests.swift */,
 			);
@@ -387,6 +397,7 @@
 			children = (
 				6ACB15D11BC7F1D0006C029C /* Map.swift */,
 				3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */,
+				030114A81D95187600FBFD4F /* ImmutableMappble.swift */,
 				6AAC8FC419F048FE00E7A677 /* Mapper.swift */,
 				6AAC8FC519F048FE00E7A677 /* Operators.swift */,
 				6AAC8FC319F048FE00E7A677 /* FromJSON.swift */,
@@ -710,6 +721,7 @@
 				6AC6923F1BE3FD3A004C119A /* URLTransform.swift in Sources */,
 				6AC692401BE3FD3A004C119A /* EnumTransform.swift in Sources */,
 				C135CABC1D7631DC00BA9338 /* DataTransform.swift in Sources */,
+				030114B11D951A7500FBFD4F /* ImmutableMappble.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -735,6 +747,7 @@
 				6AC692461BE3FD45004C119A /* NestedArrayTests.swift in Sources */,
 				DC99C8CE1CA261AE005C788C /* NullableKeysFromJSONTests.swift in Sources */,
 				6AC692471BE3FD45004C119A /* ObjectMapperTests.swift in Sources */,
+				030114AE1D951A5600FBFD4F /* ImmutableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -759,6 +772,7 @@
 				6A2AD04F1B2C786C0097E150 /* URLTransform.swift in Sources */,
 				6A2AD0501B2C786C0097E150 /* EnumTransform.swift in Sources */,
 				C135CABB1D7631DB00BA9338 /* DataTransform.swift in Sources */,
+				030114B01D951A7100FBFD4F /* ImmutableMappble.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -776,6 +790,7 @@
 				BC1E7F371ABC44C000F9B1CF /* EnumTransform.swift in Sources */,
 				D86BDEA41A51E5AD00120819 /* ISO8601DateTransform.swift in Sources */,
 				CD71C8C11A7218AD009D4161 /* TransformOf.swift in Sources */,
+				030114A91D95187600FBFD4F /* ImmutableMappble.swift in Sources */,
 				6A6C54D019FE8DB600239454 /* URLTransform.swift in Sources */,
 				6A51372C1AADDE2700B82516 /* DateFormatterTransform.swift in Sources */,
 				6AAC8FCE19F048FE00E7A677 /* Mapper.swift in Sources */,
@@ -808,6 +823,7 @@
 				6AAC8F8619F03C2900E7A677 /* ObjectMapperTests.swift in Sources */,
 				DC99C8CC1CA261A8005C788C /* NullableKeysFromJSONTests.swift in Sources */,
 				6100B1C01BD76A030011114A /* NestedArrayTests.swift in Sources */,
+				030114AC1D951A4F00FBFD4F /* ImmutableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -817,6 +833,7 @@
 			files = (
 				CD1603221AC02472000CD69A /* TransformType.swift in Sources */,
 				3BAD2C0D1BDDB10D00E6B203 /* Mappable.swift in Sources */,
+				030114AF1D951A6C00FBFD4F /* ImmutableMappble.swift in Sources */,
 				CD1603201AC02461000CD69A /* CustomDateFormatTransform.swift in Sources */,
 				CD16031E1AC02461000CD69A /* DateFormatterTransform.swift in Sources */,
 				84D4F8531CC3B643008B0FB6 /* NSDecimalNumberTransform.swift in Sources */,
@@ -857,6 +874,7 @@
 				6A412A251BB0DA26001C3F67 /* PerformanceTests.swift in Sources */,
 				DC99C8CD1CA261AD005C788C /* NullableKeysFromJSONTests.swift in Sources */,
 				CD1603281AC02480000CD69A /* CustomTransformTests.swift in Sources */,
+				030114AD1D951A5300FBFD4F /* ImmutableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ObjectMapper/Core/ImmutableMappble.swift
+++ b/ObjectMapper/Core/ImmutableMappble.swift
@@ -1,0 +1,177 @@
+//
+//  ImmutableMappble.swift
+//  ObjectMapper
+//
+//  Created by Suyeol Jeon on 23/09/2016.
+//  Copyright © 2016 hearst. All rights reserved.
+//
+
+public struct MapError: Error {
+	public var key: String?
+	public var currentValue: Any?
+	public var reason: String?
+}
+
+extension MapError: CustomStringConvertible {
+	public var description: String {
+		let info: [(String, Any?)] = [
+			("reason", reason),
+			("key", key),
+			("currentValue", currentValue),
+		]
+		let infoString = info.map { "\($0)=\($1 ?? "nil")" }.joined(separator: ", ")
+		return "Got an error while mapping. (\(infoString))"
+	}
+}
+
+public protocol ImmutableMappable: BaseMappable {
+	init(map: Map) throws
+}
+
+public extension ImmutableMappable {
+	/// Implement this method to support object -> JSON transform.
+	public func mapping(map: Map) {}
+}
+
+extension Map {
+
+	fileprivate func currentValue(for key: String) -> Any? {
+		return self[key].currentValue
+	}
+
+}
+
+public extension Map {
+
+	// MARK: Basic
+
+	/// Returns a value or throws an error.
+	public func value<T>(_ key: String) throws -> T {
+		let currentValue = self.currentValue(for: key)
+		guard let value = currentValue as? T else {
+			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '\(T.self)'")
+		}
+		return value
+	}
+
+	/// Returns a transformed value or throws an error.
+	public func value<Transform: TransformType>(_ key: String, using transform: Transform) throws -> Transform.Object {
+		let currentValue = self.currentValue(for: key)
+		guard let value = transform.transformFromJSON(currentValue) else {
+			throw MapError(key: key, currentValue: currentValue, reason: "Cannot transform to '\(Transform.Object.self)' using \(transform)")
+		}
+		return value
+	}
+
+	// MARK: BaseMappable
+
+	/// Returns a `BaseMappable` object or throws an error.
+	public func value<T: BaseMappable>(_ key: String) throws -> T {
+		let currentValue = self.currentValue(for: key)
+    return try Mapper<T>().mapOrFail(JSONObject: currentValue)
+	}
+
+	// MARK: [BaseMappable]
+
+	/// Returns a `[BaseMappable]` or throws an error.
+	public func value<T: BaseMappable>(_ key: String) throws -> [T] {
+		let currentValue = self.currentValue(for: key)
+		guard let jsonArray = currentValue as? [Any] else {
+			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '[Any]'")
+		}
+		return try jsonArray.enumerated().map { i, json -> T in
+      return try Mapper<T>().mapOrFail(JSONObject: json)
+		}
+	}
+
+	/// Returns a `[BaseMapple]` using transform or throws an error.
+	public func value<Transform: TransformType>(_ key: String, using transform: Transform) throws -> [Transform.Object] {
+		let currentValue = self.currentValue(for: key)
+		guard let jsonArray = currentValue as? [Any] else {
+			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '[Any]' ")
+		}
+		return try jsonArray.enumerated().map { i, json -> Transform.Object in
+			guard let object = transform.transformFromJSON(json) else {
+				throw MapError(key: "\(key)[\(i)]", currentValue: json, reason: "Cannot transform to '\(Transform.Object.self)' using \(transform)")
+			}
+			return object
+		}
+	}
+
+	// MARK: [String: BaseMappable]
+
+	/// Returns a `[String: BaseMappable]` or throws an error.
+	public func value<T: BaseMappable>(_ key: String) throws -> [String: T] {
+		let currentValue = self.currentValue(for: key)
+		guard let jsonDictionary = currentValue as? [String: Any] else {
+			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '[String: Any]'")
+		}
+		var value: [String: T] = [:]
+		for (key, json) in jsonDictionary {
+      value[key] = try Mapper<T>().mapOrFail(JSONObject: json)
+		}
+		return value
+	}
+
+	/// Returns a `[String: BaseMappable]` using transform or throws an error.
+	public func value<Transform: TransformType>(_ key: String, using transform: Transform) throws -> [String: Transform.Object] {
+		let currentValue = self.currentValue(for: key)
+		guard let jsonDictionary = currentValue as? [String: Any] else {
+			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '[String: Any]'")
+		}
+		var value: [String: Transform.Object] = [:]
+		for (key, json) in jsonDictionary {
+			guard let object = transform.transformFromJSON(json) else {
+				throw MapError(key: key, currentValue: json, reason: "Cannot transform to '\(Transform.Object.self)' using \(transform)")
+			}
+			value[key] = object
+		}
+		return value
+	}
+
+}
+
+public extension Mapper where N: ImmutableMappable {
+
+	public func map(JSON: [String: Any]) throws -> N {
+		return try self.mapOrFail(JSON: JSON)
+	}
+
+	public func map(JSONString: String) throws -> N {
+		return try mapOrFail(JSONString: JSONString)
+	}
+
+	public func map(JSONObject: Any?) throws -> N {
+		return try mapOrFail(JSONObject: JSONObject)
+	}
+
+}
+
+internal extension Mapper where N: BaseMappable {
+
+	internal func mapOrFail(JSON: [String: Any]) throws -> N {
+		let map = Map(mappingType: .fromJSON, JSON: JSON, context: context)
+		if let klass = N.self as? ImmutableMappable.Type {
+			return try klass.init(map: map) as! N
+		}
+		guard let value = self.map(JSON: JSON) else {
+			throw MapError(key: nil, currentValue: JSON, reason: "Cannot map to '\(N.self)'")
+		}
+		return value
+	}
+
+	internal func mapOrFail(JSONString: String) throws -> N {
+		guard let JSON = Mapper.parseJSONStringIntoDictionary(JSONString: JSONString) else {
+			throw MapError(key: nil, currentValue: JSONString, reason: "Cannot parse into '[String: Any]'")
+		}
+		return try mapOrFail(JSON: JSON)
+	}
+
+	internal func mapOrFail(JSONObject: Any?) throws -> N {
+		guard let JSON = JSONObject as? [String: Any] else {
+			throw MapError(key: nil, currentValue: JSONObject, reason: "Cannot cast to '[String: Any]'")
+		}
+		return try mapOrFail(JSON: JSON)
+	}
+
+}

--- a/ObjectMapper/Core/ImmutableMappble.swift
+++ b/ObjectMapper/Core/ImmutableMappble.swift
@@ -152,6 +152,21 @@ public extension Map {
 
 }
 
+public extension ImmutableMappable {
+	
+	/// Initializes object from a JSON String
+	public init(JSONString: String, context: MapContext? = nil) throws {
+		self = try Mapper(context: context).map(JSONString: JSONString)
+	}
+	
+	/// Initializes object from a JSON Dictionary
+	public init(JSON: [String: Any], context: MapContext? = nil) throws {
+		self = try Mapper(context: context).map(JSON: JSON)
+	}
+
+}
+
+
 public extension Mapper where N: ImmutableMappable {
 
 	public func map(JSON: [String: Any]) throws -> N {

--- a/ObjectMapperTests/ImmutableTests.swift
+++ b/ObjectMapperTests/ImmutableTests.swift
@@ -1,0 +1,257 @@
+//
+//  ImmutableTests.swift
+//  ObjectMapper
+//
+//  Created by Suyeol Jeon on 23/09/2016.
+//  Copyright © 2016 hearst. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import ObjectMapper
+
+class ImmutableObjectTests: XCTestCase {
+
+	func testImmutableMappable() {
+		let mapper = Mapper<Struct>()
+		let JSON: [String: Any] = [
+			
+			// Basic types
+			"prop1": "Immutable!",
+			"prop2": 255,
+			"prop3": true,
+			// prop4 has a default value
+			
+			// String
+			"prop5": "prop5",
+			"prop6": "prop6",
+			"prop7": "prop7",
+			
+			// [String]
+			"prop8": ["prop8"],
+			"prop9": ["prop9"],
+			"prop10": ["prop10"],
+			
+			// [String: String]
+			"prop11": ["key": "prop11"],
+			"prop12": ["key": "prop12"],
+			"prop13": ["key": "prop13"],
+			
+			// Base
+			"prop14": ["base": "prop14"],
+			"prop15": ["base": "prop15"],
+			"prop16": ["base": "prop16"],
+			
+			// [Base]
+			"prop17": [["base": "prop17"]],
+			"prop18": [["base": "prop18"]],
+			"prop19": [["base": "prop19"]],
+			
+			// [String: Base]
+			"prop20": ["key": ["base": "prop20"]],
+			"prop21": ["key": ["base": "prop21"]],
+			"prop22": ["key": ["base": "prop22"]],
+		]
+		
+		let immutable: Struct = try! mapper.map(JSON: JSON)
+		XCTAssertNotNil(immutable)
+		XCTAssertEqual(immutable.prop1, "Immutable!")
+		XCTAssertEqual(immutable.prop2, 255)
+		XCTAssertEqual(immutable.prop3, true)
+		XCTAssertEqual(immutable.prop4, DBL_MAX)
+		
+		XCTAssertEqual(immutable.prop5, "prop5_TRANSFORMED")
+		XCTAssertEqual(immutable.prop6, "prop6_TRANSFORMED")
+		XCTAssertEqual(immutable.prop7, "prop7_TRANSFORMED")
+		
+		XCTAssertEqual(immutable.prop8, ["prop8_TRANSFORMED"])
+		XCTAssertEqual(immutable.prop9!, ["prop9_TRANSFORMED"])
+		XCTAssertEqual(immutable.prop10, ["prop10_TRANSFORMED"])
+		
+		XCTAssertEqual(immutable.prop11, ["key": "prop11_TRANSFORMED"])
+		XCTAssertEqual(immutable.prop12!, ["key": "prop12_TRANSFORMED"])
+		XCTAssertEqual(immutable.prop13, ["key": "prop13_TRANSFORMED"])
+		
+		XCTAssertEqual(immutable.prop14.base, "prop14")
+		XCTAssertEqual(immutable.prop15?.base, "prop15")
+		XCTAssertEqual(immutable.prop16.base, "prop16")
+		
+		XCTAssertEqual(immutable.prop17[0].base, "prop17")
+		XCTAssertEqual(immutable.prop18![0].base, "prop18")
+		XCTAssertEqual(immutable.prop19[0].base, "prop19")
+		
+		XCTAssertEqual(immutable.prop20["key"]!.base, "prop20")
+		XCTAssertEqual(immutable.prop21!["key"]!.base, "prop21")
+		XCTAssertEqual(immutable.prop22["key"]!.base, "prop22")
+		
+		let JSON2: [String: Any] = [ "prop1": "prop1", "prop2": NSNull() ]
+		let immutable2 = try? mapper.map(JSON: JSON2)
+		XCTAssertNil(immutable2)
+
+		// TODO: ImmutableMappble to JSON
+		let JSONFromObject = mapper.toJSON(immutable)
+		let objectFromJSON = try? mapper.map(JSON: JSONFromObject)
+		XCTAssertNotNil(objectFromJSON)
+		assertImmutableObjectsEqual(objectFromJSON!, immutable)
+	}
+
+}
+
+struct Struct {
+	let prop1: String
+	let prop2: Int
+	let prop3: Bool
+	let prop4: Double
+	
+	let prop5: String
+	let prop6: String?
+	let prop7: String!
+	
+	let prop8: [String]
+	let prop9: [String]?
+	let prop10: [String]!
+	
+	let prop11: [String: String]
+	let prop12: [String: String]?
+	let prop13: [String: String]!
+	
+	let prop14: Base
+	let prop15: Base?
+	let prop16: Base!
+	
+	let prop17: [Base]
+	let prop18: [Base]?
+	let prop19: [Base]!
+	
+	let prop20: [String: Base]
+	let prop21: [String: Base]?
+	let prop22: [String: Base]!
+}
+
+extension Struct: ImmutableMappable {
+	init(map: Map) throws {
+		prop1 = try map.value("prop1")
+		prop2 = try map.value("prop2")
+		prop3 = try map.value("prop3")
+		prop4 = (try? map.value("prop4")) ?? DBL_MAX
+		
+		prop5 = try map.value("prop5", using: stringTransform)
+		prop6 = try? map.value("prop6", using: stringTransform)
+		prop7 = try? map.value("prop7", using: stringTransform)
+		
+		prop8 = try map.value("prop8", using: stringTransform)
+		prop9 = try? map.value("prop9", using: stringTransform)
+		prop10 = try? map.value("prop10", using: stringTransform)
+
+		prop11 = try map.value("prop11", using: stringTransform)
+		prop12 = try? map.value("prop12", using: stringTransform)
+		prop13 = try? map.value("prop13", using: stringTransform)
+
+		prop14 = try map.value("prop14")
+		prop15 = try? map.value("prop15")
+		prop16 = try? map.value("prop16")
+		
+		prop17 = try map.value("prop17")
+		prop18 = try? map.value("prop18")
+		prop19 = try? map.value("prop19")
+		
+		prop20 = try map.value("prop20")
+		prop21 = try? map.value("prop21")
+		prop22 = try? map.value("prop22")
+	}
+
+	mutating func mapping(map: Map) {
+		guard case .toJSON = map.mappingType else { return }
+
+		var prop1 = self.prop1
+		var prop2 = self.prop2
+		var prop3 = self.prop3
+		var prop4 = self.prop4
+		var prop5 = self.prop5
+		var prop6 = self.prop6
+		var prop7 = self.prop7
+		var prop8 = self.prop8
+		var prop9 = self.prop9
+		var prop10 = self.prop10
+		var prop11 = self.prop11
+		var prop12 = self.prop12
+		var prop13 = self.prop13
+		var prop14 = self.prop14
+		var prop15 = self.prop15
+		var prop16 = self.prop16
+		var prop17 = self.prop17
+		var prop18 = self.prop18
+		var prop19 = self.prop19
+		var prop20 = self.prop20
+		var prop21 = self.prop21
+		var prop22 = self.prop22
+
+		prop1 <- map["prop1"]
+		prop2 <- map["prop2"]
+		prop3 <- map["prop3"]
+		prop4 <- map["prop4"]
+		
+		prop5 <- (map["prop5"], stringTransform)
+		prop6 <- (map["prop6"], stringTransform)
+		prop7 <- (map["prop7"], stringTransform)
+		
+		prop8 <- (map["prop8"], stringTransform)
+		prop9 <- (map["prop9"], stringTransform)
+		prop10 <- (map["prop10"], stringTransform)
+
+		prop11 <- (map["prop11"], stringTransform)
+		prop12 <- (map["prop12"], stringTransform)
+		prop13 <- (map["prop13"], stringTransform)
+
+		prop14 <- map["prop14"]
+		prop15 <- map["prop15"]
+		prop16 <- map["prop16"]
+		
+		prop17 <- map["prop17"]
+		prop18 <- map["prop18"]
+		prop19 <- map["prop19"]
+		
+		prop20 <- map["prop20"]
+		prop21 <- map["prop21"]
+		prop22 <- map["prop22"]
+	}
+}
+
+let stringTransform = TransformOf<String, String>(
+	fromJSON: { (str: String?) -> String? in
+		guard let str = str else {
+			return nil
+		}
+		return "\(str)_TRANSFORMED"
+	},
+	toJSON: { (str: String?) -> String? in
+		return str?.replacingOccurrences(of: "_TRANSFORMED", with: "", options: [], range: nil)
+	}
+)
+
+private func assertImmutableObjectsEqual(_ lhs: Struct, _ rhs: Struct) {
+	XCTAssertEqual(lhs.prop1, rhs.prop1)
+	XCTAssertEqual(lhs.prop2, rhs.prop2)
+	XCTAssertEqual(lhs.prop3, rhs.prop3)
+	XCTAssertEqual(lhs.prop4, rhs.prop4)
+	XCTAssertEqual(lhs.prop5, rhs.prop5)
+	XCTAssertEqual(lhs.prop6, rhs.prop6)
+	XCTAssertEqual(lhs.prop7, rhs.prop7)
+	XCTAssertEqual(lhs.prop8, rhs.prop8)
+	
+	// @hack: compare arrays and objects with their string representation.
+	XCTAssertEqual("\(lhs.prop9)", "\(rhs.prop9)")
+	XCTAssertEqual("\(lhs.prop10)", "\(rhs.prop10)")
+	XCTAssertEqual("\(lhs.prop11)", "\(rhs.prop11)")
+	XCTAssertEqual("\(lhs.prop12)", "\(rhs.prop12)")
+	XCTAssertEqual("\(lhs.prop13)", "\(rhs.prop13)")
+	XCTAssertEqual("\(lhs.prop14)", "\(rhs.prop14)")
+	XCTAssertEqual("\(lhs.prop15)", "\(rhs.prop15)")
+	XCTAssertEqual("\(lhs.prop16)", "\(rhs.prop16)")
+	XCTAssertEqual("\(lhs.prop17)", "\(rhs.prop17)")
+	XCTAssertEqual("\(lhs.prop18)", "\(rhs.prop18)")
+	XCTAssertEqual("\(lhs.prop19)", "\(rhs.prop19)")
+	XCTAssertEqual("\(lhs.prop20)", "\(rhs.prop20)")
+	XCTAssertEqual("\(lhs.prop21)", "\(rhs.prop21)")
+	XCTAssertEqual("\(lhs.prop22)", "\(rhs.prop22)")
+}


### PR DESCRIPTION
Related to #383, #384

## Summary

* Supports Swift 3
* This PR doesn't break existing implementation.
* Adds `ImmutableMappable` to support immutables.
* `ImmutableMappable` has `init(map:) throws`.
* `ImmutableMappable` makes `func mapping(map:)` optional; basically supports transforming from JSON to Immutable object. Users needs to implement this function to support reverse transform (object to JSON).
    * `init(map:) throws`: JSON -> Object
    * `mapping(map:)`: Object -> JSON

## Example

**User**

```swift
struct User {
  let name: String
  let createdAt: Date
  let updatedAt: Date?
  let posts: [Post]

  // JSON -> Object
  init(map: Map) throws {
    name = try map.value("name") // throws an error if fails
    createdAt = try map.value("createdAt", using: DateTransform()) // throws an error if fails
    updatedAt = try? map.value("updatedAt", using: DateTransform()) // optional
    posts = (try? map.value("posts")) ?? [] // optional + default value
  }

  // Optional: Object -> JSON
  mutating func mapping(map: Map) {
    guard case .toJSON = map.mappingType else { return }
    
    var name = self.name
    var createdAt = self.createdAt
    var updatedAt = self.updatedAt
    var posts = self.posts

    name <- map["name"]
    createdAt <- (map["createdAt"], DateTransform())
    updatedAt <- (map["updatedAt"], DateTransform())
    posts <- map["posts"]
  }
}
```

**Usage**

```swift
let user = try User(JSONString: JSONString)
```

## Discussion

* Will it better to provide `toJSON(map:)` or something else instead of `mapping(map:)` for `ImmutableMappable`s?
