### PR TITLE
Make transformFromJSON() and transformToJSON() open

### DIFF
--- a/ObjectMapper/Transforms/DataTransform.swift
+++ b/ObjectMapper/Transforms/DataTransform.swift
@@ -34,14 +34,14 @@ open class DataTransform: TransformType {
 	
 	public init() {}
 	
-	public func transformFromJSON(_ value: Any?) -> Data? {
+	open func transformFromJSON(_ value: Any?) -> Data? {
 		guard let string = value as? String else{
 			return nil
 		}
 		return Data(base64Encoded: string)
 	}
 	
-	public func transformToJSON(_ value: Data?) -> String? {
+	open func transformToJSON(_ value: Data?) -> String? {
 		guard let data = value else{
 			return nil
 		}

--- a/ObjectMapper/Transforms/EnumTransform.swift
+++ b/ObjectMapper/Transforms/EnumTransform.swift
@@ -34,14 +34,14 @@ open class EnumTransform<T: RawRepresentable>: TransformType {
 	
 	public init() {}
 	
-	public func transformFromJSON(_ value: Any?) -> T? {
+	open func transformFromJSON(_ value: Any?) -> T? {
 		if let raw = value as? T.RawValue {
 			return T(rawValue: raw)
 		}
 		return nil
 	}
 	
-	public func transformToJSON(_ value: T?) -> T.RawValue? {
+	open func transformToJSON(_ value: T?) -> T.RawValue? {
 		if let obj = value {
 			return obj.rawValue
 		}

--- a/ObjectMapper/Transforms/NSDecimalNumberTransform.swift
+++ b/ObjectMapper/Transforms/NSDecimalNumberTransform.swift
@@ -34,7 +34,7 @@ open class NSDecimalNumberTransform: TransformType {
 
     public init() {}
 
-    public func transformFromJSON(_ value: Any?) -> NSDecimalNumber? {
+    open func transformFromJSON(_ value: Any?) -> NSDecimalNumber? {
         if let string = value as? String {
             return NSDecimalNumber(string: string)
         }
@@ -44,7 +44,7 @@ open class NSDecimalNumberTransform: TransformType {
         return nil
     }
 
-    public func transformToJSON(_ value: NSDecimalNumber?) -> String? {
+    open func transformToJSON(_ value: NSDecimalNumber?) -> String? {
         guard let value = value else { return nil }
         return value.description
     }

--- a/ObjectMapper/Transforms/TransformOf.swift
+++ b/ObjectMapper/Transforms/TransformOf.swift
@@ -38,11 +38,11 @@ open class TransformOf<ObjectType, JSONType>: TransformType {
 		self.toJSON = toJSON
 	}
 
-	public func transformFromJSON(_ value: Any?) -> ObjectType? {
+	open func transformFromJSON(_ value: Any?) -> ObjectType? {
 		return fromJSON(value as? JSONType)
 	}
 
-	public func transformToJSON(_ value: ObjectType?) -> JSONType? {
+	open func transformToJSON(_ value: ObjectType?) -> JSONType? {
 		return toJSON(value)
 	}
 }

--- a/ObjectMapper/Transforms/URLTransform.swift
+++ b/ObjectMapper/Transforms/URLTransform.swift
@@ -43,7 +43,7 @@ open class URLTransform: TransformType {
 		self.shouldEncodeURLString = shouldEncodeURLString
 	}
 
-	public func transformFromJSON(_ value: Any?) -> URL? {
+	open func transformFromJSON(_ value: Any?) -> URL? {
 		guard let URLString = value as? String else { return nil }
 		
 		if !shouldEncodeURLString {
@@ -56,7 +56,7 @@ open class URLTransform: TransformType {
 		return URL(string: escapedURLString)
 	}
 
-	public func transformToJSON(_ value: URL?) -> String? {
+	open func transformToJSON(_ value: URL?) -> String? {
 		if let URL = value {
 			return URL.absoluteString
 		}


### PR DESCRIPTION
This PR makes it available to override `transformFromJSON()` and `transformToJSON()` from its subclasses by replacing `public func` with `open func`. For details, see [SE-0117](https://github.com/apple/swift-evolution/blob/master/proposals/0117-non-public-subclassable-by-default.md) which introduces `open` access modifier.

- Fix #580
