### PR TITLE
Add additional immutable mapping supports

### DIFF
--- a/Sources/ImmutableMappable.swift
+++ b/Sources/ImmutableMappable.swift
@@ -181,6 +181,29 @@ public extension Mapper where N: ImmutableMappable {
 		
 		return try mapArray(JSONArray: JSONArray)
 	}
+
+	// MARK: Dictionary mapping functions
+
+	public func mapDictionary(JSONString: String) throws -> [String: N] {
+		guard let JSONObject = Mapper.parseJSONString(JSONString: JSONString) else {
+			throw MapError(key: nil, currentValue: JSONString, reason: "Cannot convert string into Any'")
+		}
+
+		return try mapDictionary(JSONObject: JSONObject)
+	}
+
+	public func mapDictionary(JSONObject: Any?) throws -> [String: N] {
+		guard let JSON = JSONObject as? [String: [String: Any]] else {
+			throw MapError(key: nil, currentValue: JSONObject, reason: "Cannot cast to '[String: [String: Any]]''")
+		}
+
+		return try mapDictionary(JSON: JSON)
+	}
+
+	public func mapDictionary(JSON: [String: [String: Any]]) throws -> [String: N] {
+		return try JSON.filterMap(mapOrFail)
+	}
+
 }
 
 internal extension Mapper where N: BaseMappable {

--- a/Sources/ImmutableMappable.swift
+++ b/Sources/ImmutableMappable.swift
@@ -219,6 +219,15 @@ public extension Mapper where N: ImmutableMappable {
 		}
 	}
 
+	// MARK: 2 dimentional array mapping functions
+
+	public func mapArrayOfArrays(JSONObject: Any?) throws -> [[N]] {
+		guard let JSONArray = JSONObject as? [[[String: Any]]] else {
+			throw MapError(key: nil, currentValue: JSONObject, reason: "Cannot cast to '[[[String: Any]]]''")
+		}
+		return try JSONArray.map(mapArray)
+	}
+
 }
 
 internal extension Mapper where N: BaseMappable {

--- a/Sources/ImmutableMappable.swift
+++ b/Sources/ImmutableMappable.swift
@@ -204,6 +204,21 @@ public extension Mapper where N: ImmutableMappable {
 		return try JSON.filterMap(mapOrFail)
 	}
 
+	// MARK: Dictinoary of arrays mapping functions
+
+	public func mapDictionaryOfArrays(JSONObject: Any?) throws -> [String: [N]] {
+		guard let JSON = JSONObject as? [String: [[String: Any]]] else {
+			throw MapError(key: nil, currentValue: JSONObject, reason: "Cannot cast to '[String: [String: Any]]''")
+		}
+		return try mapDictionaryOfArrays(JSON: JSON)
+	}
+
+	public func mapDictionaryOfArrays(JSON: [String: [[String: Any]]]) throws -> [String: [N]] {
+		return try JSON.filterMap { array -> [N] in
+			try mapArray(JSONArray: array)
+		}
+	}
+
 }
 
 internal extension Mapper where N: BaseMappable {

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -393,22 +393,22 @@ extension Mapper where N: Hashable {
 }
 
 extension Dictionary {
-	internal func map<K: Hashable, V>(_ f: (Element) -> (K, V)) -> [K: V] {
+	internal func map<K: Hashable, V>(_ f: (Element) throws -> (K, V)) rethrows -> [K: V] {
 		var mapped = [K: V]()
 
 		for element in self {
-			let newElement = f(element)
+			let newElement = try f(element)
 			mapped[newElement.0] = newElement.1
 		}
 
 		return mapped
 	}
 
-	internal func map<K: Hashable, V>(_ f: (Element) -> (K, [V])) -> [K: [V]] {
+	internal func map<K: Hashable, V>(_ f: (Element) throws -> (K, [V])) rethrows -> [K: [V]] {
 		var mapped = [K: [V]]()
 		
 		for element in self {
-			let newElement = f(element)
+			let newElement = try f(element)
 			mapped[newElement.0] = newElement.1
 		}
 		
@@ -416,11 +416,11 @@ extension Dictionary {
 	}
 
 	
-	internal func filterMap<U>(_ f: (Value) -> U?) -> [Key: U] {
+	internal func filterMap<U>(_ f: (Value) throws -> U?) rethrows -> [Key: U] {
 		var mapped = [Key: U]()
 
 		for (key, value) in self {
-			if let newValue = f(value) {
+			if let newValue = try f(value) {
 				mapped[key] = newValue
 			}
 		}

--- a/Tests/ImmutableTests.swift
+++ b/Tests/ImmutableTests.swift
@@ -194,6 +194,34 @@ class ImmutableObjectTests: XCTestCase {
 		XCTAssertThrowsError(try Mapper<Struct>().mapDictionaryOfArrays(JSON: JSONDictionary))
 	}
 
+	func testMappingArrayOfArrays() {
+		let JSONArray: [[[String: Any]]] = [
+			[JSON, JSON],
+			[JSON],
+			[],
+		]
+		let array: [[Struct]] = try! Mapper<Struct>().mapArrayOfArrays(JSONObject: JSONArray)
+		XCTAssertNotNil(array.first)
+		XCTAssertEqual(array.count, 3)
+		XCTAssertEqual(array[0].count, 2)
+		XCTAssertEqual(array[1].count, 1)
+		XCTAssertEqual(array[2].count, 0)
+	}
+
+	func testMappingArrayOfArrays_empty() {
+		let JSONArray: [[[String: Any]]] = []
+		let array: [[Struct]] = try! Mapper<Struct>().mapArrayOfArrays(JSONObject: JSONArray)
+		XCTAssertTrue(array.isEmpty)
+	}
+
+	func testMappingArrayOfArrays_throws() {
+		let JSONArray: [[[String: Any]]] = [
+			[JSON],
+			[["invalid": "dictionary"]],
+		]
+		XCTAssertThrowsError(try Mapper<Struct>().mapArrayOfArrays(JSONObject: JSONArray))
+	}
+
 }
 
 struct Struct {

--- a/Tests/ImmutableTests.swift
+++ b/Tests/ImmutableTests.swift
@@ -162,6 +162,38 @@ class ImmutableObjectTests: XCTestCase {
 		XCTAssertThrowsError(try Mapper<Struct>().mapDictionary(JSON: JSONDictionary))
 	}
 
+	func testMappingFromDictionaryOfArrays() {
+		let JSONDictionary: [String: [[String: Any]]] = [
+			"key1": [JSON, JSON],
+			"key2": [JSON],
+			"key3": [],
+		]
+
+		let dictionary: [String: [Struct]] = try! Mapper<Struct>().mapDictionaryOfArrays(JSON: JSONDictionary)
+		XCTAssertNotNil(dictionary.first)
+		XCTAssertEqual(dictionary.count, 3)
+		XCTAssertEqual(Set(dictionary.keys), Set(["key1", "key2", "key3"]))
+		XCTAssertEqual(dictionary["key1"]?.count, 2)
+		XCTAssertEqual(dictionary["key2"]?.count, 1)
+		XCTAssertEqual(dictionary["key3"]?.count, 0)
+	}
+
+	func testMappingFromDictionaryOfArrays_empty() {
+		let JSONDictionary: [String: [[String: Any]]] = [:]
+
+		let dictionary: [String: [Struct]] = try! Mapper<Struct>().mapDictionaryOfArrays(JSON: JSONDictionary)
+		XCTAssertTrue(dictionary.isEmpty)
+	}
+
+	func testMappingFromDictionaryOfArrays_throws() {
+		let JSONDictionary: [String: [[String: Any]]] = [
+			"key1": [JSON],
+			"key2": [["invalid": "dictionary"]],
+		]
+
+		XCTAssertThrowsError(try Mapper<Struct>().mapDictionaryOfArrays(JSON: JSONDictionary))
+	}
+
 }
 
 struct Struct {

--- a/Tests/ImmutableTests.swift
+++ b/Tests/ImmutableTests.swift
@@ -134,6 +134,34 @@ class ImmutableObjectTests: XCTestCase {
 		XCTAssertNotNil(array.first)
 	}
 
+	func testMappingFromDictionary() {
+		let JSONDictionary: [String: [String: Any]] = [
+			"key1": JSON,
+			"key2": JSON,
+		]
+
+		let dictionary: [String: Struct] = try! Mapper<Struct>().mapDictionary(JSON: JSONDictionary)
+		XCTAssertNotNil(dictionary.first)
+		XCTAssertEqual(dictionary.count, 2)
+		XCTAssertEqual(Set(dictionary.keys), Set(["key1", "key2"]))
+	}
+
+	func testMappingFromDictionary_empty() {
+		let JSONDictionary: [String: [String: Any]] = [:]
+
+		let dictionary: [String: Struct] = try! Mapper<Struct>().mapDictionary(JSON: JSONDictionary)
+		XCTAssertTrue(dictionary.isEmpty)
+	}
+
+	func testMappingFromDictionary_throws() {
+		let JSONDictionary: [String: [String: Any]] = [
+			"key1": JSON,
+			"key2": ["invalid": "dictionary"],
+		]
+
+		XCTAssertThrowsError(try Mapper<Struct>().mapDictionary(JSON: JSONDictionary))
+	}
+
 }
 
 struct Struct {


### PR DESCRIPTION
- Related to: #617, e98adbffcb1e0dc9f995de4805cc01c236415cf7

```swift
func mapDictionary(JSON: [String: [String: Any]]) throws -> [String: ImmutableMappable]
func mapDictionaryOfArrays(JSON: [String: [[String: Any]]]) throws -> [String: [ImmutableMappable]]
func mapArrayOfArrays(JSON: [[[String: Any]]]]) throws -> [[ImmutableMappable]]
```

All of them are throwables.