### PR TITLE
fix documentation to indicate the correct type

### DIFF
--- a/Sources/Mappable.swift
+++ b/Sources/Mappable.swift
@@ -42,7 +42,7 @@ public protocol Mappable: BaseMappable {
 public protocol StaticMappable: BaseMappable {
 	/// This is function that can be used to:
 	///		1) provide an existing cached object to be used for mapping
-	///		2) return an object of another class (which conforms to Mappable) to be used for mapping. For instance, you may inspect the JSON to infer the type of object that should be used for any given mapping
+	///		2) return an object of another class (which conforms to BaseMappable) to be used for mapping. For instance, you may inspect the JSON to infer the type of object that should be used for any given mapping
 	static func objectForMapping(map: Map) -> BaseMappable?
 }
 


### PR DESCRIPTION
the function only requires an instance conforming to `BaseMappable` to be
returned