### PR TITLE
ISO8601 dates matching by regex

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -218,7 +218,7 @@
 		030114A81D95187600FBFD4F /* ImmutableMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmutableMappable.swift; sourceTree = "<group>"; };
 		030114AA1D95197100FBFD4F /* ImmutableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmutableTests.swift; sourceTree = "<group>"; };
 		37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomDateFormatTransform.swift; sourceTree = "<group>"; };
-		3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Mappable.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Mappable.swift; sourceTree = "<group>"; };
 		3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MappableExtensionsTests.swift; sourceTree = "<group>"; };
 		6100B1BF1BD76A020011114A /* NestedArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NestedArrayTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6A05B7A61BE274BE00F19B53 /* ObjectMapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectMapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/Sources/ISO8601DateTransform.swift
+++ b/Sources/ISO8601DateTransform.swift
@@ -33,29 +33,24 @@ open class ISO8601DateTransform: DateFormatterTransform {
 	public init() {
 		let formatter = DateFormatter()
 		formatter.locale = Locale(identifier: "en_US_POSIX")
-		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+		formatter.dateFormat = "year-MM-dd'T'HH:mm:ssZZZZZ"
 		
 		super.init(dateFormatter: formatter)
 	}
     
-    
     override open func transformFromJSON(_ value: Any?) -> Date? {
-        
         guard let value = value as? String else {
             return nil
         }
- 
         let actualFormat = formatFrom(value)        
         dateFormatter.dateFormat = actualFormat.dateFormat
         return super.transformFromJSON(value)
     }
-    
-    
-  
+	
     /// get the current date string and try to find a valid format string for that string and returns the a valid format and a valid date to set them into a DateFormatter  
     func formatFrom(_ value:String) -> (dateString:String?, dateFormat:String?) {
         
-        var regexString = "\\A(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2})" // Mandatory - YYYY-MM-DDTHH:mm
+        var regexString = "\\A(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2})" // Mandatory - year-MM-DDTHH:mm
         regexString = regexString + ":?(\\d{2})?"                             // Optional - :ss
         regexString = regexString + "[.]?(\\d{1,6})?"                         // Optional - .nnnnnn
         regexString = regexString + "([+-])?(\\d{2})?:?(\\d{2})?|Z"           // Optional -[+-]hh:mm or Z
@@ -74,11 +69,7 @@ open class ISO8601DateTransform: DateFormatterTransform {
         guard let matches = matchesResult, matches.count > 0 else {
             return (nil, nil)
         }
-        
-        var YYYY: String?, MM: String?, DD: String?, hh: String?, mm: String?, ss: String?, nn: String?, sign: String?, Zhh: String?, Zmm: String?
-        var tempRange: NSRange!
-        
-        
+		
         //this function is to convert a NSRange to Range<String.Index>
         let convertRange:(_ nsRange: NSRange, _ text:String) -> Range<String.Index>? = { nsRange, text in
             guard
@@ -89,12 +80,13 @@ open class ISO8601DateTransform: DateFormatterTransform {
                 else { return nil }
             return from ..< to
         }
-        
-        
+		
+		var year, month, day, hour, minutes, seconds, secondFraction, sign, timeZoneHour, timeZoneMinutes: String?
+		var tempRange: NSRange!
+		
         for match in matches {
             let matchCount = match.numberOfRanges - 1
             var idx = 0 //components start from 1, 0 is the complete string
-            
             let checkAndAssign:()->(String?) = {
                 if idx < matchCount {
                     idx = idx + 1
@@ -105,73 +97,68 @@ open class ISO8601DateTransform: DateFormatterTransform {
                 return nil
             }
             
-            YYYY = checkAndAssign()
-            MM = checkAndAssign()
-            DD = checkAndAssign()
-            hh = checkAndAssign()
-            mm = checkAndAssign()
-            ss = checkAndAssign()
-            nn = checkAndAssign()
+            year = checkAndAssign()
+            month = checkAndAssign()
+            day = checkAndAssign()
+            hour = checkAndAssign()
+            minutes = checkAndAssign()
+            seconds = checkAndAssign()
+            secondFraction = checkAndAssign()
             sign = checkAndAssign()
-            Zhh = checkAndAssign()
-            Zmm = checkAndAssign()
+            timeZoneHour = checkAndAssign()
+            timeZoneMinutes = checkAndAssign()
         }
         
         var dateString:String = ""
         var formatString:String = ""
         
-        if let YYYY = YYYY {
-            dateString = dateString + YYYY + "-"
+        if let year = year {
+            dateString = dateString + year + "-"
             formatString = formatString + "yyyy" + "-"
         }
         
-        if let MM = MM {
-            dateString = dateString + MM + "-"
+        if let month = month {
+            dateString = dateString + month + "-"
             formatString = formatString + "MM" + "-"
         }
         
-        if let DD = DD {
-            dateString = dateString + DD
+        if let day = day {
+            dateString = dateString + day
             formatString = formatString + "dd"
         }
         
-        if let hh = hh {
-            dateString = dateString + "T" + hh
+        if let hour = hour {
+            dateString = dateString + "T" + hour
             formatString = formatString + "'T'" + "HH"
         }
         
-        if let mm = mm {
-            dateString = dateString + ":" + mm
+        if let minutes = minutes {
+            dateString = dateString + ":" + minutes
             formatString = formatString + ":" + "mm"
         }
         
-        if let ss = ss {
-            dateString = dateString + ":" + ss
+        if let seconds = seconds {
+            dateString = dateString + ":" + seconds
             formatString = formatString + ":" + "ss"
         }
-        if let nn = nn {
-            dateString = dateString + "." + nn
-            formatString = formatString + "." + String(repeating: "S", count: nn.characters.count)
+        if let secondFraction = secondFraction {
+            dateString = dateString + "." + secondFraction
+            formatString = formatString + "." + String(repeating: "S", count: secondFraction.characters.count)
         }
         if let sign = sign {
             dateString = dateString  + sign
             formatString = formatString + "Z"
         }
-        if let Zhh = Zhh {
-            dateString = dateString + Zhh
+        if let timeZoneHour = timeZoneHour {
+            dateString = dateString + timeZoneHour
             formatString = formatString + "ZZ"
         }
         
-        if let Zmm = Zmm {
-            dateString = dateString + Zmm
+        if let timeZoneMinutes = timeZoneMinutes {
+            dateString = dateString + timeZoneMinutes
             formatString = formatString + "ZZ"
         }
         
         return (dateString, formatString)
     }
-    
-    
-    
 }
-
-

--- a/Sources/ISO8601DateTransform.swift
+++ b/Sources/ISO8601DateTransform.swift
@@ -37,5 +37,141 @@ open class ISO8601DateTransform: DateFormatterTransform {
 		
 		super.init(dateFormatter: formatter)
 	}
-	
+    
+    
+    override open func transformFromJSON(_ value: Any?) -> Date? {
+        
+        guard let value = value as? String else {
+            return nil
+        }
+ 
+        let actualFormat = formatFrom(value)        
+        dateFormatter.dateFormat = actualFormat.dateFormat
+        return super.transformFromJSON(value)
+    }
+    
+    
+  
+    /// get the current date string and try to find a valid format string for that string and returns the a valid format and a valid date to set them into a DateFormatter  
+    func formatFrom(_ value:String) -> (dateString:String?, dateFormat:String?) {
+        
+        var regexString = "\\A(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2})" // Mandatory - YYYY-MM-DDTHH:mm
+        regexString = regexString + ":?(\\d{2})?"                             // Optional - :ss
+        regexString = regexString + "[.]?(\\d{1,6})?"                         // Optional - .nnnnnn
+        regexString = regexString + "([+-])?(\\d{2})?:?(\\d{2})?|Z"           // Optional -[+-]hh:mm or Z
+        regexString = regexString + "\\z"
+        
+        let regex: NSRegularExpression?
+        var matchesResult: [NSTextCheckingResult]?
+        do{
+            regex = try NSRegularExpression (pattern: regexString, options: NSRegularExpression.Options.caseInsensitive)
+            
+            matchesResult = regex!.matches(in:value, options: NSRegularExpression.MatchingOptions.reportCompletion, range:NSMakeRange(0, value.characters.count))
+        } catch{
+            return (nil, nil)
+        }
+        
+        guard let matches = matchesResult, matches.count > 0 else {
+            return (nil, nil)
+        }
+        
+        var YYYY: String?, MM: String?, DD: String?, hh: String?, mm: String?, ss: String?, nn: String?, sign: String?, Zhh: String?, Zmm: String?
+        var tempRange: NSRange!
+        
+        
+        //this function is to convert a NSRange to Range<String.Index>
+        let convertRange:(_ nsRange: NSRange, _ text:String) -> Range<String.Index>? = { nsRange, text in
+            guard
+                let from16 = text.utf16.index(text.utf16.startIndex, offsetBy: nsRange.location, limitedBy: text.utf16.endIndex),
+                let to16 = text.utf16.index(from16, offsetBy: nsRange.length, limitedBy: text.utf16.endIndex),
+                let from = String.Index(from16, within: text),
+                let to = String.Index(to16, within: text)
+                else { return nil }
+            return from ..< to
+        }
+        
+        
+        for match in matches {
+            let matchCount = match.numberOfRanges - 1
+            var idx = 0 //components start from 1, 0 is the complete string
+            
+            let checkAndAssign:()->(String?) = {
+                if idx < matchCount {
+                    idx = idx + 1
+                    tempRange = match.rangeAt(idx)
+                    let substring:String? = tempRange.location != NSNotFound ? value.substring(with: convertRange(tempRange, value)!) : nil
+                    return substring
+                }
+                return nil
+            }
+            
+            YYYY = checkAndAssign()
+            MM = checkAndAssign()
+            DD = checkAndAssign()
+            hh = checkAndAssign()
+            mm = checkAndAssign()
+            ss = checkAndAssign()
+            nn = checkAndAssign()
+            sign = checkAndAssign()
+            Zhh = checkAndAssign()
+            Zmm = checkAndAssign()
+        }
+        
+        var dateString:String = ""
+        var formatString:String = ""
+        
+        if let YYYY = YYYY {
+            dateString = dateString + YYYY + "-"
+            formatString = formatString + "yyyy" + "-"
+        }
+        
+        if let MM = MM {
+            dateString = dateString + MM + "-"
+            formatString = formatString + "MM" + "-"
+        }
+        
+        if let DD = DD {
+            dateString = dateString + DD
+            formatString = formatString + "dd"
+        }
+        
+        if let hh = hh {
+            dateString = dateString + "T" + hh
+            formatString = formatString + "'T'" + "HH"
+        }
+        
+        if let mm = mm {
+            dateString = dateString + ":" + mm
+            formatString = formatString + ":" + "mm"
+        }
+        
+        if let ss = ss {
+            dateString = dateString + ":" + ss
+            formatString = formatString + ":" + "ss"
+        }
+        if let nn = nn {
+            dateString = dateString + "." + nn
+            formatString = formatString + "." + String(repeating: "S", count: nn.characters.count)
+        }
+        if let sign = sign {
+            dateString = dateString  + sign
+            formatString = formatString + "Z"
+        }
+        if let Zhh = Zhh {
+            dateString = dateString + Zhh
+            formatString = formatString + "ZZ"
+        }
+        
+        if let Zmm = Zmm {
+            dateString = dateString + Zmm
+            formatString = formatString + "ZZ"
+        }
+        
+        return (dateString, formatString)
+    }
+    
+    
+    
 }
+
+

--- a/Sources/ISO8601DateTransform.swift
+++ b/Sources/ISO8601DateTransform.swift
@@ -33,7 +33,7 @@ open class ISO8601DateTransform: DateFormatterTransform {
 	public init() {
 		let formatter = DateFormatter()
 		formatter.locale = Locale(identifier: "en_US_POSIX")
-		formatter.dateFormat = "year-MM-dd'T'HH:mm:ssZZZZZ"
+		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
 		
 		super.init(dateFormatter: formatter)
 	}

--- a/Tests/CustomTransformTests.swift
+++ b/Tests/CustomTransformTests.swift
@@ -82,8 +82,7 @@ class CustomTransformTests: XCTestCase {
 		XCTAssertEqual(parsedTransforms?.ISO8601DateOpt, transforms.ISO8601DateOpt)
 	}
 	
-	
-	func testMoreISO8601FormatsDateTransform() {
+	func testMoreFormatsISO8601DateTransform() {
 		
 		let formatter = DateFormatter()
 		formatter.locale = Locale(identifier: "en_US_POSIX")
@@ -91,14 +90,11 @@ class CustomTransformTests: XCTestCase {
 		let transforms = Transforms()
 		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
 		transforms.ISO8601Date = formatter.date(from: "2016-10-24T10:20:30.349-0500")!
-		
 		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
 		transforms.ISO8601DateOpt = formatter.date(from: "2016-10-24T10:20:30Z")
 		
-		
 		let JSON = ["ISO8601Date" : "2016-10-24T10:20:30.349-0500",
 		            "ISO8601DateOpt" : "2016-10-24T10:20:30Z"]
-		
 		let parsedTransforms = mapper.map(JSON: JSON)
 		XCTAssertNotNil(parsedTransforms)
 		XCTAssertEqual(parsedTransforms?.ISO8601Date, transforms.ISO8601Date)

--- a/Tests/CustomTransformTests.swift
+++ b/Tests/CustomTransformTests.swift
@@ -82,6 +82,29 @@ class CustomTransformTests: XCTestCase {
 		XCTAssertEqual(parsedTransforms?.ISO8601DateOpt, transforms.ISO8601DateOpt)
 	}
 	
+	
+	func testMoreISO8601FormatsDateTransform() {
+		
+		let formatter = DateFormatter()
+		formatter.locale = Locale(identifier: "en_US_POSIX")
+		
+		let transforms = Transforms()
+		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+		transforms.ISO8601Date = formatter.date(from: "2016-10-24T10:20:30.349-0500")!
+		
+		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+		transforms.ISO8601DateOpt = formatter.date(from: "2016-10-24T10:20:30Z")
+		
+		
+		let JSON = ["ISO8601Date" : "2016-10-24T10:20:30.349-0500",
+		            "ISO8601DateOpt" : "2016-10-24T10:20:30Z"]
+		
+		let parsedTransforms = mapper.map(JSON: JSON)
+		XCTAssertNotNil(parsedTransforms)
+		XCTAssertEqual(parsedTransforms?.ISO8601Date, transforms.ISO8601Date)
+		XCTAssertEqual(parsedTransforms?.ISO8601DateOpt, transforms.ISO8601DateOpt)
+	}
+	
 	func testISO8601DateTransformWithInvalidInput() {
 		var JSON: [String: Any] = ["ISO8601Date": ""]
 		let transforms = mapper.map(JSON: JSON)


### PR DESCRIPTION
issue #641 
- : validate every ISO8601 date format and map it into a valid date
- : method `testMoreISO8601FormatsDateTransform` to test different ISO8601 formats 

validate the string of the date by regex and create a valid format string and valid date string to create the Date with the DateFormatter
