### PR TITLE
Fixes assertion failed on ImmutableMappable object

### DIFF
--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -104,6 +104,15 @@ public final class Mapper<N: BaseMappable> {
 				object.mapping(map: map)
 				return object
 			}
+		} else if let klass = N.self as? ImmutableMappable.Type { // Check if object is ImmutableMappable
+			do {
+				if var object = try klass.init(map: map) as? N {
+					object.mapping(map: map)
+					return object
+				}
+			} catch {
+				return nil
+			}
 		} else {
 			// Ensure BaseMappable is not implemented directly
 			assert(false, "BaseMappable should not be implemented directly. Please implement Mappable, StaticMappable or ImmutableMappable")


### PR DESCRIPTION
- The method Mapper.map(JSON:) -> N? fails an assertion when the
BaseMappable object implements the ImmutableMappable protocol, because
so far the only BaseMappable-derived protocols being considered were
StaticMappable and Mappable.
- This commit adds check for ImmutableMappable, preventing an assertion
failed in this case.