### PR TITLE
Add UnsignedInteger/SignedInteger mapping operators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode8.2
 
 env:
   global:
@@ -10,10 +10,10 @@ env:
     - OSX_FRAMEWORK_SCHEME="ObjectMapper-Mac"
     - TVOS_FRAMEWORK_SCHEME="ObjectMapper-tvOS"
     - WATCHOS_FRAMEWORK_SCHEME="ObjectMapper-watchOS"
-    - IOS_SDK=iphonesimulator10.0
+    - IOS_SDK=iphonesimulator10.2
     - OSX_SDK=macosx10.12
-    - TVOS_SDK=appletvsimulator10.0
-    - WATCHOS_SDK=watchsimulator3.0    
+    - TVOS_SDK=appletvsimulator10.1
+    - WATCHOS_SDK=watchsimulator3.1
   matrix:
     - DESTINATION="OS=10.0,name=iPhone 5"            SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES"
     - DESTINATION="OS=10.0,name=iPhone 5S"           SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES"
@@ -23,7 +23,7 @@ env:
     - DESTINATION="OS=10.0,name=iPhone 6S Plus"      SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES"
     - DESTINATION="arch=x86_64"                      SCHEME="$OSX_FRAMEWORK_SCHEME"     SDK="$OSX_SDK"     RUN_TESTS="YES"
     - DESTINATION="OS=10.0,name=Apple TV 1080p"      SCHEME="$TVOS_FRAMEWORK_SCHEME"    SDK="$TVOS_SDK"    RUN_TESTS="YES"
-    - DESTINATION="OS=3.0,name=Apple Watch - 38mm"   SCHEME="$WATCHOS_FRAMEWORK_SCHEME" SDK="$WATCHOS_SDK" RUN_TESTS="NO"
+    - DESTINATION="OS=3.1,name=Apple Watch - 38mm"   SCHEME="$WATCHOS_FRAMEWORK_SCHEME" SDK="$WATCHOS_SDK" RUN_TESTS="NO"
 
 before_install:
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		030114AF1D951A6C00FBFD4F /* ImmutableMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114A81D95187600FBFD4F /* ImmutableMappable.swift */; };
 		030114B01D951A7100FBFD4F /* ImmutableMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114A81D95187600FBFD4F /* ImmutableMappable.swift */; };
 		030114B11D951A7500FBFD4F /* ImmutableMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114A81D95187600FBFD4F /* ImmutableMappable.swift */; };
+		030E75F51E588BF30027D94A /* IntegerOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038F0A021E55FE2400613148 /* IntegerOperators.swift */; };
+		030E75F61E588BF80027D94A /* IntegerOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038F0A021E55FE2400613148 /* IntegerOperators.swift */; };
+		030E75F71E588BFC0027D94A /* IntegerOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038F0A021E55FE2400613148 /* IntegerOperators.swift */; };
 		038F0A031E55FE2400613148 /* IntegerOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038F0A021E55FE2400613148 /* IntegerOperators.swift */; };
 		37AFD9B91AAD191C00AB59B5 /* CustomDateFormatTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */; };
 		3BAD2C0C1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
@@ -747,6 +750,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				030E75F71E588BFC0027D94A /* IntegerOperators.swift in Sources */,
 				6AA1F66E1BE991FF006EF513 /* Mappable.swift in Sources */,
 				6AC692341BE3FD3A004C119A /* Map.swift in Sources */,
 				6AF148901D99A7A6002BEA2C /* TransformOperators.swift in Sources */,
@@ -803,6 +807,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				030E75F61E588BF80027D94A /* IntegerOperators.swift in Sources */,
 				6A2AD0451B2C786C0097E150 /* Mapper.swift in Sources */,
 				3BAD2C0E1BDDB10D00E6B203 /* Mappable.swift in Sources */,
 				6AF1488F1D99A7A6002BEA2C /* TransformOperators.swift in Sources */,
@@ -889,6 +894,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				030E75F51E588BF30027D94A /* IntegerOperators.swift in Sources */,
 				CD1603221AC02472000CD69A /* TransformType.swift in Sources */,
 				3BAD2C0D1BDDB10D00E6B203 /* Mappable.swift in Sources */,
 				6AF1488E1D99A7A6002BEA2C /* TransformOperators.swift in Sources */,

--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		030114AF1D951A6C00FBFD4F /* ImmutableMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114A81D95187600FBFD4F /* ImmutableMappable.swift */; };
 		030114B01D951A7100FBFD4F /* ImmutableMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114A81D95187600FBFD4F /* ImmutableMappable.swift */; };
 		030114B11D951A7500FBFD4F /* ImmutableMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030114A81D95187600FBFD4F /* ImmutableMappable.swift */; };
+		038F0A031E55FE2400613148 /* IntegerOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038F0A021E55FE2400613148 /* IntegerOperators.swift */; };
 		37AFD9B91AAD191C00AB59B5 /* CustomDateFormatTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */; };
 		3BAD2C0C1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
 		3BAD2C0D1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
@@ -217,6 +218,7 @@
 /* Begin PBXFileReference section */
 		030114A81D95187600FBFD4F /* ImmutableMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmutableMappable.swift; sourceTree = "<group>"; };
 		030114AA1D95197100FBFD4F /* ImmutableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImmutableTests.swift; path = ObjectMapperTests/ImmutableTests.swift; sourceTree = "<group>"; };
+		038F0A021E55FE2400613148 /* IntegerOperators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegerOperators.swift; sourceTree = "<group>"; };
 		37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomDateFormatTransform.swift; sourceTree = "<group>"; };
 		3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Mappable.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MappableExtensionsTests.swift; path = ObjectMapperTests/MappableExtensionsTests.swift; sourceTree = "<group>"; };
@@ -456,6 +458,7 @@
 				6AAC8FC519F048FE00E7A677 /* Operators.swift */,
 				6AF148911D99A7CA002BEA2C /* EnumOperators.swift */,
 				6AF1488C1D99A7A6002BEA2C /* TransformOperators.swift */,
+				038F0A021E55FE2400613148 /* IntegerOperators.swift */,
 			);
 			name = Operators;
 			sourceTree = "<group>";
@@ -843,6 +846,7 @@
 				CD71C8C11A7218AD009D4161 /* TransformOf.swift in Sources */,
 				030114A91D95187600FBFD4F /* ImmutableMappable.swift in Sources */,
 				6A6C54D019FE8DB600239454 /* URLTransform.swift in Sources */,
+				038F0A031E55FE2400613148 /* IntegerOperators.swift in Sources */,
 				6A51372C1AADDE2700B82516 /* DateFormatterTransform.swift in Sources */,
 				6AAC8FCE19F048FE00E7A677 /* Mapper.swift in Sources */,
 				6AAC8FCD19F048FE00E7A677 /* FromJSON.swift in Sources */,

--- a/Sources/IntegerOperators.swift
+++ b/Sources/IntegerOperators.swift
@@ -1,0 +1,63 @@
+//
+//  IntegerOperators.swift
+//  ObjectMapper
+//
+//  Created by Suyeol Jeon on 17/02/2017.
+//  Copyright © 2017 hearst. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Signed Integer
+
+/// SignedInteger mapping
+public func <- <T: SignedInteger>(left: inout T, right: Map) {
+	switch right.mappingType {
+	case .fromJSON where right.isKeyPresent:
+		let value = (right.currentValue as? Int).flatMap(IntMax.init).flatMap(T.init)
+		FromJSON.basicType(&left, object: value)
+	case .toJSON:
+		left >>> right
+	default: ()
+	}
+}
+
+/// Optional SignedInteger mapping
+public func <- <T: SignedInteger>(left: inout T?, right: Map) {
+	switch right.mappingType {
+	case .fromJSON where right.isKeyPresent:
+		let value = (right.currentValue as? Int).flatMap(IntMax.init).flatMap(T.init)
+		FromJSON.basicType(&left, object: value)
+	case .toJSON:
+		left >>> right
+	default: ()
+	}
+}
+
+
+// MARK: - Unsigned Integer
+
+/// UnsignedInteger mapping
+public func <- <T: UnsignedInteger>(left: inout T, right: Map) {
+	switch right.mappingType {
+	case .fromJSON where right.isKeyPresent:
+		let value = (right.currentValue as? Int).flatMap(UIntMax.init).flatMap(T.init)
+		FromJSON.basicType(&left, object: value)
+	case .toJSON:
+		left >>> right
+	default: ()
+	}
+}
+
+
+/// Optional UnsignedInteger mapping
+public func <- <T: UnsignedInteger>(left: inout T?, right: Map) {
+	switch right.mappingType {
+	case .fromJSON where right.isKeyPresent:
+		let value = (right.currentValue as? Int).flatMap(UIntMax.init).flatMap(T.init)
+		FromJSON.basicType(&left, object: value)
+	case .toJSON:
+		left >>> right
+	default: ()
+	}
+}

--- a/Tests/ObjectMapperTests/BasicTypes.swift
+++ b/Tests/ObjectMapperTests/BasicTypes.swift
@@ -36,6 +36,15 @@ class BasicTypes: Mappable {
 	var int: Int = 0
 	var intOptional: Int?
 	var intImplicityUnwrapped: Int!
+	var int64: Int64 = 0
+	var int64Optional: Int64?
+	var int64ImplicityUnwrapped: Int64!
+	var uint: UInt = 0
+	var uintOptional: UInt?
+	var uintImplicityUnwrapped: UInt!
+	var uint64: UInt64 = 0
+	var uint64Optional: UInt64?
+	var uint64ImplicityUnwrapped: UInt64!
 	var double: Double = 1.1
 	var doubleOptional: Double?
 	var doubleImplicityUnwrapped: Double!
@@ -142,6 +151,15 @@ class BasicTypes: Mappable {
 		int									<- map["int"]
 		intOptional							<- map["intOpt"]
 		intImplicityUnwrapped				<- map["intImp"]
+		int64											<- map["int64"]
+    int64Optional							<- map["int64Opt"]
+		int64ImplicityUnwrapped		<- map["int64Imp"]
+    uint											<- map["uint"]
+    uintOptional							<- map["uintOpt"]
+		uintImplicityUnwrapped		<- map["uintImp"]
+    uint64										<- map["uint64"]
+    uint64Optional						<- map["uint64Opt"]
+		uint64ImplicityUnwrapped	<- map["uint64Imp"]
 		double								<- map["double"]
 		doubleOptional						<- map["doubleOpt"]
 		doubleImplicityUnwrapped			<- map["doubleImp"]

--- a/Tests/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/Tests/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -60,7 +60,7 @@ class BasicTypesTestsFromJSON: XCTestCase {
 	
 	func testMappingIntFromJSON(){
 		let value: Int = 11
-		let JSONString = "{\"int\" : \(value), \"intOpt\" : \(value), \"intImp\" : \(value)}"
+		let JSONString = "{\"int\" : \(value), \"intOpt\" : \(value), \"intImp\" : \(value), \"int64\": \(value), \"int64Opt\": \(value), \"int64Imp\": \(value)}"
 		
 		let mappedObject = mapper.map(JSONString: JSONString)
 
@@ -68,6 +68,24 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		XCTAssertEqual(mappedObject?.int, value)
 		XCTAssertEqual(mappedObject?.intOptional, value)
 		XCTAssertEqual(mappedObject?.intImplicityUnwrapped, value)
+		XCTAssertEqual(mappedObject?.int64, Int64(value))
+		XCTAssertEqual(mappedObject?.int64Optional, Int64(value))
+		XCTAssertEqual(mappedObject?.int64ImplicityUnwrapped, Int64(value))
+	}
+
+	func testMappingUIntFromJSON(){
+		let value: UInt = 11
+		let JSONString = "{\"uint\" : \(value), \"uintOpt\" : \(value), \"uintImp\" : \(value), \"uint64\": \(value), \"uint64Opt\": \(value), \"uint64Imp\": \(value)}"
+		
+		let mappedObject = mapper.map(JSONString: JSONString)
+
+		XCTAssertNotNil(mappedObject)
+		XCTAssertEqual(mappedObject?.uint, value)
+		XCTAssertEqual(mappedObject?.uintOptional, value)
+		XCTAssertEqual(mappedObject?.uintImplicityUnwrapped, value)
+		XCTAssertEqual(mappedObject?.uint64, UInt64(value))
+		XCTAssertEqual(mappedObject?.uint64Optional, UInt64(value))
+		XCTAssertEqual(mappedObject?.uint64ImplicityUnwrapped, UInt64(value))
 	}
 	
 	func testMappingDoubleFromJSON(){

--- a/Tests/ObjectMapperTests/BasicTypesTestsToJSON.swift
+++ b/Tests/ObjectMapperTests/BasicTypesTestsToJSON.swift
@@ -80,6 +80,9 @@ class BasicTypesTestsToJSON: XCTestCase {
 		object.int = value
 		object.intOptional = value
 		object.intImplicityUnwrapped = value
+		object.int64 = Int64(value)
+		object.int64Optional = Int64(value)
+		object.int64ImplicityUnwrapped = Int64(value)
 		
 		let JSONString = Mapper().toJSONString(object, prettyPrint: true)
 		let mappedObject = mapper.map(JSONString: JSONString!)
@@ -88,6 +91,31 @@ class BasicTypesTestsToJSON: XCTestCase {
 		XCTAssertEqual(mappedObject?.int, value)
 		XCTAssertEqual(mappedObject?.intOptional, value)
 		XCTAssertEqual(mappedObject?.intImplicityUnwrapped, value)
+		XCTAssertEqual(mappedObject?.int64, Int64(value))
+		XCTAssertEqual(mappedObject?.int64Optional, Int64(value))
+		XCTAssertEqual(mappedObject?.int64ImplicityUnwrapped, Int64(value))
+	}
+
+	func testMappingUIntToJSON(){
+		let value: UInt = 11
+		let object = BasicTypes()
+		object.uint = value
+		object.uintOptional = value
+		object.uintImplicityUnwrapped = value
+		object.uint64 = UInt64(value)
+		object.uint64Optional = UInt64(value)
+		object.uint64ImplicityUnwrapped = UInt64(value)
+		
+		let JSONString = Mapper().toJSONString(object, prettyPrint: true)
+		let mappedObject = mapper.map(JSONString: JSONString!)
+
+		XCTAssertNotNil(mappedObject)
+		XCTAssertEqual(mappedObject?.uint, value)
+		XCTAssertEqual(mappedObject?.uintOptional, value)
+		XCTAssertEqual(mappedObject?.uintImplicityUnwrapped, value)
+		XCTAssertEqual(mappedObject?.uint64, UInt64(value))
+		XCTAssertEqual(mappedObject?.uint64Optional, UInt64(value))
+		XCTAssertEqual(mappedObject?.uint64ImplicityUnwrapped, UInt64(value))
 	}
 
 	func testMappingDoubleToJSON(){


### PR DESCRIPTION
## Background

```swift
struct MyModel: Mappable {
  var value: UInt = 0

  mutating func mapping(map: Map) {
    self.value <- map["value"]
  }
}

let json: [String: Any] = ["value": 123]
MyModel(JSON: json)?.value // 0 (expected 123)
```

`<-` operator for mapping `UInt` uses [basic type mapping function](https://github.com/Hearst-DD/ObjectMapper/blob/master/Sources/Operators.swift#L44-L52). Basic type mapping uses [`Map.value()`](https://github.com/Hearst-DD/ObjectMapper/blob/2.2.3/Sources/Map.swift#L122-L124) function to get type-casted value], but `Int` cannot be casted to `UInt` using `as`.

## Workaround

There are two protocols that wrap integer types: `SignedInteger` and `UnsignedInteger`. This PR adds `<-` operator functions to support mapping of both protocols.

## Related Issues

* Thie PR resolves #751
