### PR TITLE
Allow for non-subscripted maps to be passed to TransformTypes

### DIFF
--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -53,6 +53,7 @@ public final class Map {
 				
 		self.mappingType = mappingType
 		self.JSON = JSON
+		self.currentValue = JSON
 		self.toObject = toObject
 		self.context = context
 		self.shouldIncludeNilValues = shouldIncludeNilValues

--- a/Sources/TransformOperators.swift
+++ b/Sources/TransformOperators.swift
@@ -14,7 +14,7 @@ import Foundation
 public func <- <Transform: TransformType>(left: inout Transform.Object, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let value = transform.transformFromJSON(map.currentValue)
 		FromJSON.basicType(&left, object: value)
 	case .toJSON:
@@ -36,7 +36,7 @@ public func >>> <Transform: TransformType>(left: Transform.Object, right: (Map, 
 public func <- <Transform: TransformType>(left: inout Transform.Object?, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let value = transform.transformFromJSON(map.currentValue)
 		FromJSON.optionalBasicType(&left, object: value)
 	case .toJSON:
@@ -58,7 +58,7 @@ public func >>> <Transform: TransformType>(left: Transform.Object?, right: (Map,
 public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let value = transform.transformFromJSON(map.currentValue)
 		FromJSON.optionalBasicType(&left, object: value)
 	case .toJSON:
@@ -71,7 +71,7 @@ public func <- <Transform: TransformType>(left: inout Transform.Object!, right: 
 public func <- <Transform: TransformType>(left: inout [Transform.Object], right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let values = fromJSONArrayWithTransform(map.currentValue, transform: transform)
 		FromJSON.basicType(&left, object: values)
 	case .toJSON:
@@ -93,7 +93,7 @@ public func >>> <Transform: TransformType>(left: [Transform.Object], right: (Map
 public func <- <Transform: TransformType>(left: inout [Transform.Object]?, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let values = fromJSONArrayWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: values)
 	case .toJSON:
@@ -115,7 +115,7 @@ public func >>> <Transform: TransformType>(left: [Transform.Object]?, right: (Ma
 public func <- <Transform: TransformType>(left: inout [Transform.Object]!, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let values = fromJSONArrayWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: values)
 	case .toJSON:
@@ -128,7 +128,7 @@ public func <- <Transform: TransformType>(left: inout [Transform.Object]!, right
 public func <- <Transform: TransformType>(left: inout [String: Transform.Object], right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let values = fromJSONDictionaryWithTransform(map.currentValue, transform: transform)
 		FromJSON.basicType(&left, object: values)
 	case .toJSON:
@@ -150,7 +150,7 @@ public func >>> <Transform: TransformType>(left: [String: Transform.Object], rig
 public func <- <Transform: TransformType>(left: inout [String: Transform.Object]?, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let values = fromJSONDictionaryWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: values)
 	case .toJSON:
@@ -172,7 +172,7 @@ public func >>> <Transform: TransformType>(left: [String: Transform.Object]?, ri
 public func <- <Transform: TransformType>(left: inout [String: Transform.Object]!, right: (Map, Transform)) {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let values = fromJSONDictionaryWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: values)
 	case .toJSON:
@@ -187,7 +187,7 @@ public func <- <Transform: TransformType>(left: inout [String: Transform.Object]
 public func <- <Transform: TransformType>(left: inout Transform.Object, right: (Map, Transform)) where Transform.Object: BaseMappable {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let value: Transform.Object? = transform.transformFromJSON(map.currentValue)
 		FromJSON.basicType(&left, object: value)
 	case .toJSON:
@@ -209,7 +209,7 @@ public func >>> <Transform: TransformType>(left: Transform.Object, right: (Map, 
 public func <- <Transform: TransformType>(left: inout Transform.Object?, right: (Map, Transform)) where Transform.Object: BaseMappable {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let value: Transform.Object? = transform.transformFromJSON(map.currentValue)
 		FromJSON.optionalBasicType(&left, object: value)
 	case .toJSON:
@@ -231,7 +231,7 @@ public func >>> <Transform: TransformType>(left: Transform.Object?, right: (Map,
 public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (Map, Transform)) where Transform.Object: BaseMappable {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let value: Transform.Object? = transform.transformFromJSON(map.currentValue)
 		FromJSON.optionalBasicType(&left, object: value)
 	case .toJSON:
@@ -391,7 +391,7 @@ public func <- <Transform: TransformType>(left: inout Dictionary<String, [Transf
 public func <- <Transform: TransformType>(left: inout Array<Transform.Object>, right: (Map, Transform)) where Transform.Object: BaseMappable {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		if let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform) {
 			FromJSON.basicType(&left, object: transformedValues)
 		}
@@ -414,7 +414,7 @@ public func >>> <Transform: TransformType>(left: Array<Transform.Object>, right:
 public func <- <Transform: TransformType>(left: inout Array<Transform.Object>?, right: (Map, Transform)) where Transform.Object: BaseMappable {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: transformedValues)
 	case .toJSON:
@@ -436,7 +436,7 @@ public func >>> <Transform: TransformType>(left: Array<Transform.Object>?, right
 public func <- <Transform: TransformType>(left: inout Array<Transform.Object>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform)
 		FromJSON.optionalBasicType(&left, object: transformedValues)
 	case .toJSON:
@@ -514,7 +514,7 @@ public func <- <Transform: TransformType>(left: inout Array<Array<Transform.Obje
 public func <- <Transform: TransformType>(left: inout Set<Transform.Object>, right: (Map, Transform)) where Transform.Object: Hashable & BaseMappable {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		if let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform) {
 			FromJSON.basicType(&left, object: Set(transformedValues))
 		}
@@ -537,7 +537,7 @@ public func >>> <Transform: TransformType>(left: Set<Transform.Object>, right: (
 public func <- <Transform: TransformType>(left: inout Set<Transform.Object>?, right: (Map, Transform)) where Transform.Object: Hashable & BaseMappable {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		if let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform) {
 			FromJSON.basicType(&left, object: Set(transformedValues))
 		}
@@ -562,7 +562,7 @@ public func >>> <Transform: TransformType>(left: Set<Transform.Object>?, right: 
 public func <- <Transform: TransformType>(left: inout Set<Transform.Object>!, right: (Map, Transform)) where Transform.Object: Hashable & BaseMappable {
 	let (map, transform) = right
 	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
+	case .fromJSON where map.isKeyPresent || map.currentValue != nil:
 		if let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform) {
 			FromJSON.basicType(&left, object: Set(transformedValues))
 		}

--- a/Tests/ObjectMapperTests/DictionaryTransformTests.swift
+++ b/Tests/ObjectMapperTests/DictionaryTransformTests.swift
@@ -53,6 +53,28 @@ class DictionaryTransformTests: XCTestCase {
 		XCTAssertEqual(result.dictionary[.Foo]?.foo, "bar")
 		XCTAssertEqual(result.dictionary[.Foo]?.bar, 777)
 	}
+
+	func testNonSubscriptedDictionaryTransform() {
+
+		let JSON = "{\"1\":{\"foo\":\"uno\",\"bar\":1},\"two\":{\"foo\":\"dve\",\"bar\":2},\"bar\":{\"foo\":\"bar\",\"bar\":777}}"
+
+		guard let result = NonSubscriptedDictionaryTransformTestsObject(JSONString: JSON) else {
+
+			XCTFail("Unable to parse the JSON")
+			return
+		}
+
+		XCTAssertEqual(result.dictionary.count, 3)
+
+		XCTAssertEqual(result.dictionary[.One]?.foo, "uno")
+		XCTAssertEqual(result.dictionary[.One]?.bar, 1)
+
+		XCTAssertEqual(result.dictionary[.Two]?.foo, "dve")
+		XCTAssertEqual(result.dictionary[.Two]?.bar, 2)
+
+		XCTAssertEqual(result.dictionary[.Foo]?.foo, "bar")
+		XCTAssertEqual(result.dictionary[.Foo]?.bar, 777)
+	}
 }
 
 class DictionaryTransformTestsObject: Mappable {
@@ -67,6 +89,14 @@ class DictionaryTransformTestsObject: Mappable {
 	func mapping(map: Map) {
 		
 		self.dictionary <- (map["dictionary"], DictionaryTransform<MyKey, MyValue>())
+	}
+}
+
+class NonSubscriptedDictionaryTransformTestsObject: DictionaryTransformTestsObject {
+
+	override func mapping(map: Map) {
+
+		self.dictionary <- (map, DictionaryTransform<MyKey, MyValue>())
 	}
 }
 


### PR DESCRIPTION
## Background

I've made a change to fix a bug where maps that are not subscripted do not have their values passed to TransformerTypes. 

There were two root causes of this issue:
1. A Map init function does not keep the passed JSON as currentValue, so it incorrectly states that it has none.
2. When the transform operator is run, the value of the map is only passed if it has a key present, regardless of if there is a value present.

Here is an example of when you would want this:

```swift
MyModel(JSONString: "[\"A\", \"B\", \"C\"]")

struct MyModel: Mappable {
  var value: String!

  mutating func mapping(map: Map) {
    self.value <- (map, LastItemTransformer())
  }
}
```

Say I made a transformer that transforms an array of values into whatever the last item is. Because I don't know the index of the last item, I can't use the . notation in the map subscript. However, I need to get the value from the whole map, and operate on it.

Without this fix, this would not work because the map wouldn't have a currentValue and the transformer is not passed the map's value anyway because the map has no present key.