### PR TITLE
Update IntegerOperator to cover every Integer type mappings

### DIFF
--- a/Sources/IntegerOperators.swift
+++ b/Sources/IntegerOperators.swift
@@ -14,7 +14,7 @@ import Foundation
 public func <- <T: SignedInteger>(left: inout T, right: Map) {
 	switch right.mappingType {
 	case .fromJSON where right.isKeyPresent:
-		let value = (right.currentValue as? Int).flatMap(IntMax.init).flatMap(T.init)
+		let value: T = toSignedInteger(right.currentValue) ?? 0
 		FromJSON.basicType(&left, object: value)
 	case .toJSON:
 		left >>> right
@@ -26,7 +26,19 @@ public func <- <T: SignedInteger>(left: inout T, right: Map) {
 public func <- <T: SignedInteger>(left: inout T?, right: Map) {
 	switch right.mappingType {
 	case .fromJSON where right.isKeyPresent:
-		let value = (right.currentValue as? Int).flatMap(IntMax.init).flatMap(T.init)
+		let value: T? = toSignedInteger(right.currentValue)
+		FromJSON.basicType(&left, object: value)
+	case .toJSON:
+		left >>> right
+	default: ()
+	}
+}
+
+/// ImplicitlyUnwrappedOptional SignedInteger mapping
+public func <- <T: SignedInteger>(left: inout T!, right: Map) {
+	switch right.mappingType {
+	case .fromJSON where right.isKeyPresent:
+		let value: T! = toSignedInteger(right.currentValue)
 		FromJSON.basicType(&left, object: value)
 	case .toJSON:
 		left >>> right
@@ -41,7 +53,7 @@ public func <- <T: SignedInteger>(left: inout T?, right: Map) {
 public func <- <T: UnsignedInteger>(left: inout T, right: Map) {
 	switch right.mappingType {
 	case .fromJSON where right.isKeyPresent:
-		let value = (right.currentValue as? Int).flatMap(UIntMax.init).flatMap(T.init)
+		let value: T = toUnsignedInteger(right.currentValue) ?? 0
 		FromJSON.basicType(&left, object: value)
 	case .toJSON:
 		left >>> right
@@ -54,10 +66,64 @@ public func <- <T: UnsignedInteger>(left: inout T, right: Map) {
 public func <- <T: UnsignedInteger>(left: inout T?, right: Map) {
 	switch right.mappingType {
 	case .fromJSON where right.isKeyPresent:
-		let value = (right.currentValue as? Int).flatMap(UIntMax.init).flatMap(T.init)
+		let value: T? = toUnsignedInteger(right.currentValue)
 		FromJSON.basicType(&left, object: value)
 	case .toJSON:
 		left >>> right
 	default: ()
 	}
+}
+
+/// ImplicitlyUnwrappedOptional UnsignedInteger mapping
+public func <- <T: UnsignedInteger>(left: inout T!, right: Map) {
+	switch right.mappingType {
+	case .fromJSON where right.isKeyPresent:
+		let value: T! = toUnsignedInteger(right.currentValue)
+		FromJSON.basicType(&left, object: value)
+	case .toJSON:
+		left >>> right
+	default: ()
+	}
+}
+
+// MARK: - Casting Utils
+
+/// Convert any value to `SignedInteger`.
+private func toSignedInteger<T: SignedInteger>(_ value: Any?) -> T? {
+	guard let value = value else { return nil }
+	let max: IntMax
+	switch value {
+	case let x as Int: max = .init(x)
+	case let x as Int8: max = .init(x)
+	case let x as Int16: max = .init(x)
+	case let x as Int32: max = .init(x)
+	case let x as Int64: max = .init(x)
+	case let x as UInt: max = .init(x)
+	case let x as UInt8: max = .init(x)
+	case let x as UInt16: max = .init(x)
+	case let x as UInt32: max = .init(x)
+	case let x as UInt64: max = .init(x)
+	default: return nil
+	}
+	return T.init(max)
+}
+
+/// Convert any value to `UnsignedInteger`.
+private func toUnsignedInteger<T: UnsignedInteger>(_ value: Any?) -> T? {
+	guard let value = value else { return nil }
+	let max: UIntMax
+	switch value {
+	case let x as Int: max = .init(x)
+	case let x as Int8: max = .init(x)
+	case let x as Int16: max = .init(x)
+	case let x as Int32: max = .init(x)
+	case let x as Int64: max = .init(x)
+	case let x as UInt: max = .init(x)
+	case let x as UInt8: max = .init(x)
+	case let x as UInt16: max = .init(x)
+	case let x as UInt32: max = .init(x)
+	case let x as UInt64: max = .init(x)
+	default: return nil
+	}
+	return T.init(max)
 }

--- a/Tests/ObjectMapperTests/BasicTypes.swift
+++ b/Tests/ObjectMapperTests/BasicTypes.swift
@@ -33,18 +33,47 @@ class BasicTypes: Mappable {
 	var bool: Bool = true
 	var boolOptional: Bool?
 	var boolImplicityUnwrapped: Bool!
+
 	var int: Int = 0
 	var intOptional: Int?
 	var intImplicityUnwrapped: Int!
+
+	var int8: Int8 = 0
+	var int8Optional: Int8?
+	var int8ImplicityUnwrapped: Int8!
+
+	var int16: Int16 = 0
+	var int16Optional: Int16?
+	var int16ImplicityUnwrapped: Int16!
+
+	var int32: Int32 = 0
+	var int32Optional: Int32?
+	var int32ImplicityUnwrapped: Int32!
+
 	var int64: Int64 = 0
 	var int64Optional: Int64?
 	var int64ImplicityUnwrapped: Int64!
+
 	var uint: UInt = 0
 	var uintOptional: UInt?
 	var uintImplicityUnwrapped: UInt!
+
+	var uint8: UInt8 = 0
+	var uint8Optional: UInt8?
+	var uint8ImplicityUnwrapped: UInt8!
+
+	var uint16: UInt16 = 0
+	var uint16Optional: UInt16?
+	var uint16ImplicityUnwrapped: UInt16!
+
+	var uint32: UInt32 = 0
+	var uint32Optional: UInt32?
+	var uint32ImplicityUnwrapped: UInt32!
+
 	var uint64: UInt64 = 0
 	var uint64Optional: UInt64?
 	var uint64ImplicityUnwrapped: UInt64!
+
 	var double: Double = 1.1
 	var doubleOptional: Double?
 	var doubleImplicityUnwrapped: Double!
@@ -148,18 +177,47 @@ class BasicTypes: Mappable {
 		bool								<- map["bool"]
 		boolOptional						<- map["boolOpt"]
 		boolImplicityUnwrapped				<- map["boolImp"]
+
 		int									<- map["int"]
 		intOptional							<- map["intOpt"]
 		intImplicityUnwrapped				<- map["intImp"]
+
+		int8                    <- map["int8"]
+		int8Optional            <- map["int8Opt"]
+		int8ImplicityUnwrapped  <- map["int8Imp"]
+
+		int16                   <- map["int16"]
+		int16Optional           <- map["int16Opt"]
+		int16ImplicityUnwrapped <- map["int16Imp"]
+
+		int32                   <- map["int32"]
+		int32Optional           <- map["int32Opt"]
+		int32ImplicityUnwrapped <- map["int32Imp"]
+
 		int64											<- map["int64"]
     int64Optional							<- map["int64Opt"]
 		int64ImplicityUnwrapped		<- map["int64Imp"]
+
     uint											<- map["uint"]
     uintOptional							<- map["uintOpt"]
 		uintImplicityUnwrapped		<- map["uintImp"]
+
+		uint8                    <- map["uint8"]
+		uint8Optional            <- map["uint8Opt"]
+		uint8ImplicityUnwrapped  <- map["uint8Imp"]
+
+		uint16                   <- map["uint16"]
+		uint16Optional           <- map["uint16Opt"]
+		uint16ImplicityUnwrapped <- map["uint16Imp"]
+
+		uint32                   <- map["uint32"]
+		uint32Optional           <- map["uint32Opt"]
+		uint32ImplicityUnwrapped <- map["uint32Imp"]
+
     uint64										<- map["uint64"]
     uint64Optional						<- map["uint64Opt"]
 		uint64ImplicityUnwrapped	<- map["uint64Imp"]
+
 		double								<- map["double"]
 		doubleOptional						<- map["doubleOpt"]
 		doubleImplicityUnwrapped			<- map["doubleImp"]

--- a/Tests/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/Tests/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -57,35 +57,107 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		XCTAssertEqual(mappedObject?.boolOptional, value)
 		XCTAssertEqual(mappedObject?.boolImplicityUnwrapped, value)
 	}
-	
-	func testMappingIntFromJSON(){
-		let value: Int = 11
-		let JSONString = "{\"int\" : \(value), \"intOpt\" : \(value), \"intImp\" : \(value), \"int64\": \(value), \"int64Opt\": \(value), \"int64Imp\": \(value)}"
-		
-		let mappedObject = mapper.map(JSONString: JSONString)
 
-		XCTAssertNotNil(mappedObject)
-		XCTAssertEqual(mappedObject?.int, value)
-		XCTAssertEqual(mappedObject?.intOptional, value)
-		XCTAssertEqual(mappedObject?.intImplicityUnwrapped, value)
-		XCTAssertEqual(mappedObject?.int64, Int64(value))
-		XCTAssertEqual(mappedObject?.int64Optional, Int64(value))
-		XCTAssertEqual(mappedObject?.int64ImplicityUnwrapped, Int64(value))
-	}
+	/// - warning: This test doens't consider about integer overflow/underflow.
+	func testMappingIntegerFromJSON(){
+		func parameterize<T: Integer>(_ type: T.Type) {
+			let value: T = 123
+			let json: [String: Any] = [
+				"int": value,
+				"intOpt": value,
+				"intImp": value,
 
-	func testMappingUIntFromJSON(){
-		let value: UInt = 11
-		let JSONString = "{\"uint\" : \(value), \"uintOpt\" : \(value), \"uintImp\" : \(value), \"uint64\": \(value), \"uint64Opt\": \(value), \"uint64Imp\": \(value)}"
-		
-		let mappedObject = mapper.map(JSONString: JSONString)
+				"int8": value,
+				"int8Opt": value,
+				"int8Imp": value,
 
-		XCTAssertNotNil(mappedObject)
-		XCTAssertEqual(mappedObject?.uint, value)
-		XCTAssertEqual(mappedObject?.uintOptional, value)
-		XCTAssertEqual(mappedObject?.uintImplicityUnwrapped, value)
-		XCTAssertEqual(mappedObject?.uint64, UInt64(value))
-		XCTAssertEqual(mappedObject?.uint64Optional, UInt64(value))
-		XCTAssertEqual(mappedObject?.uint64ImplicityUnwrapped, UInt64(value))
+				"int16": value,
+				"int16Opt": value,
+				"int16Imp": value,
+
+				"int32": value,
+				"int32Opt": value,
+				"int32Imp": value,
+
+				"int64": value,
+				"int64Opt": value,
+				"int64Imp": value,
+
+				"uint": value,
+				"uintOpt": value,
+				"uintImp": value,
+
+				"uint8": value,
+				"uint8Opt": value,
+				"uint8Imp": value,
+
+				"uint16": value,
+				"uint16Opt": value,
+				"uint16Imp": value,
+
+				"uint32": value,
+				"uint32Opt": value,
+				"uint32Imp": value,
+
+				"uint64": value,
+				"uint64Opt": value,
+				"uint64Imp": value,
+			]
+			let mappedObject = mapper.map(JSON: json)
+			XCTAssertNotNil(mappedObject)
+
+			XCTAssertEqual(mappedObject?.int, 123)
+			XCTAssertEqual(mappedObject?.intOptional, 123)
+			XCTAssertEqual(mappedObject?.intImplicityUnwrapped, 123)
+
+			XCTAssertEqual(mappedObject?.int8, 123)
+			XCTAssertEqual(mappedObject?.int8Optional, 123)
+			XCTAssertEqual(mappedObject?.int8ImplicityUnwrapped, 123)
+
+			XCTAssertEqual(mappedObject?.int16, 123)
+			XCTAssertEqual(mappedObject?.int16Optional, 123)
+			XCTAssertEqual(mappedObject?.int16ImplicityUnwrapped, 123)
+
+			XCTAssertEqual(mappedObject?.int32, 123)
+			XCTAssertEqual(mappedObject?.int32Optional, 123)
+			XCTAssertEqual(mappedObject?.int32ImplicityUnwrapped, 123)
+
+			XCTAssertEqual(mappedObject?.int64, 123)
+			XCTAssertEqual(mappedObject?.int64Optional, 123)
+			XCTAssertEqual(mappedObject?.int64ImplicityUnwrapped, 123)
+
+			XCTAssertEqual(mappedObject?.uint, 123)
+			XCTAssertEqual(mappedObject?.uintOptional, 123)
+			XCTAssertEqual(mappedObject?.uintImplicityUnwrapped, 123)
+
+			XCTAssertEqual(mappedObject?.uint8, 123)
+			XCTAssertEqual(mappedObject?.uint8Optional, 123)
+			XCTAssertEqual(mappedObject?.uint8ImplicityUnwrapped, 123)
+
+			XCTAssertEqual(mappedObject?.uint16, 123)
+			XCTAssertEqual(mappedObject?.uint16Optional, 123)
+			XCTAssertEqual(mappedObject?.uint16ImplicityUnwrapped, 123)
+
+			XCTAssertEqual(mappedObject?.uint32, 123)
+			XCTAssertEqual(mappedObject?.uint32Optional, 123)
+			XCTAssertEqual(mappedObject?.uint32ImplicityUnwrapped, 123)
+
+			XCTAssertEqual(mappedObject?.uint64, 123)
+			XCTAssertEqual(mappedObject?.uint64Optional, 123)
+			XCTAssertEqual(mappedObject?.uint64ImplicityUnwrapped, 123)
+		}
+
+		parameterize(Int.self)
+		parameterize(Int8.self)
+		parameterize(Int16.self)
+		parameterize(Int32.self)
+		parameterize(Int64.self)
+
+		parameterize(UInt.self)
+		parameterize(UInt8.self)
+		parameterize(UInt16.self)
+		parameterize(UInt32.self)
+		parameterize(UInt64.self)
 	}
 	
 	func testMappingDoubleFromJSON(){

--- a/Tests/ObjectMapperTests/BasicTypesTestsToJSON.swift
+++ b/Tests/ObjectMapperTests/BasicTypesTestsToJSON.swift
@@ -74,48 +74,93 @@ class BasicTypesTestsToJSON: XCTestCase {
 		XCTAssertEqual(mappedObject?.boolImplicityUnwrapped, value)
 	}
 	
-	func testMappingIntToJSON(){
-		let value: Int = 11
+	func testMappingIntegerToJSON(){
 		let object = BasicTypes()
-		object.int = value
-		object.intOptional = value
-		object.intImplicityUnwrapped = value
-		object.int64 = Int64(value)
-		object.int64Optional = Int64(value)
-		object.int64ImplicityUnwrapped = Int64(value)
-		
+
+		object.int = 123
+		object.intOptional = 123
+		object.intImplicityUnwrapped = 123
+
+		object.int8 = 123
+		object.int8Optional = 123
+		object.int8ImplicityUnwrapped = 123
+
+		object.int16 = 123
+		object.int16Optional = 123
+		object.int16ImplicityUnwrapped = 123
+
+		object.int32 = 123
+		object.int32Optional = 123
+		object.int32ImplicityUnwrapped = 123
+
+		object.int64 = 123
+		object.int64Optional = 123
+		object.int64ImplicityUnwrapped = 123
+
+		object.uint = 123
+		object.uintOptional = 123
+		object.uintImplicityUnwrapped = 123
+
+		object.uint8 = 123
+		object.uint8Optional = 123
+		object.uint8ImplicityUnwrapped = 123
+
+		object.uint16 = 123
+		object.uint16Optional = 123
+		object.uint16ImplicityUnwrapped = 123
+
+		object.uint32 = 123
+		object.uint32Optional = 123
+		object.uint32ImplicityUnwrapped = 123
+
+		object.uint64 = 123
+		object.uint64Optional = 123
+		object.uint64ImplicityUnwrapped = 123
+
 		let JSONString = Mapper().toJSONString(object, prettyPrint: true)
 		let mappedObject = mapper.map(JSONString: JSONString!)
 
 		XCTAssertNotNil(mappedObject)
-		XCTAssertEqual(mappedObject?.int, value)
-		XCTAssertEqual(mappedObject?.intOptional, value)
-		XCTAssertEqual(mappedObject?.intImplicityUnwrapped, value)
-		XCTAssertEqual(mappedObject?.int64, Int64(value))
-		XCTAssertEqual(mappedObject?.int64Optional, Int64(value))
-		XCTAssertEqual(mappedObject?.int64ImplicityUnwrapped, Int64(value))
-	}
 
-	func testMappingUIntToJSON(){
-		let value: UInt = 11
-		let object = BasicTypes()
-		object.uint = value
-		object.uintOptional = value
-		object.uintImplicityUnwrapped = value
-		object.uint64 = UInt64(value)
-		object.uint64Optional = UInt64(value)
-		object.uint64ImplicityUnwrapped = UInt64(value)
-		
-		let JSONString = Mapper().toJSONString(object, prettyPrint: true)
-		let mappedObject = mapper.map(JSONString: JSONString!)
+		XCTAssertEqual(mappedObject?.int, 123)
+		XCTAssertEqual(mappedObject?.intOptional, 123)
+		XCTAssertEqual(mappedObject?.intImplicityUnwrapped, 123)
 
-		XCTAssertNotNil(mappedObject)
-		XCTAssertEqual(mappedObject?.uint, value)
-		XCTAssertEqual(mappedObject?.uintOptional, value)
-		XCTAssertEqual(mappedObject?.uintImplicityUnwrapped, value)
-		XCTAssertEqual(mappedObject?.uint64, UInt64(value))
-		XCTAssertEqual(mappedObject?.uint64Optional, UInt64(value))
-		XCTAssertEqual(mappedObject?.uint64ImplicityUnwrapped, UInt64(value))
+		XCTAssertEqual(mappedObject?.int8, 123)
+		XCTAssertEqual(mappedObject?.int8Optional, 123)
+		XCTAssertEqual(mappedObject?.int8ImplicityUnwrapped, 123)
+
+		XCTAssertEqual(mappedObject?.int16, 123)
+		XCTAssertEqual(mappedObject?.int16Optional, 123)
+		XCTAssertEqual(mappedObject?.int16ImplicityUnwrapped, 123)
+
+		XCTAssertEqual(mappedObject?.int32, 123)
+		XCTAssertEqual(mappedObject?.int32Optional, 123)
+		XCTAssertEqual(mappedObject?.int32ImplicityUnwrapped, 123)
+
+		XCTAssertEqual(mappedObject?.int64, 123)
+		XCTAssertEqual(mappedObject?.int64Optional, 123)
+		XCTAssertEqual(mappedObject?.int64ImplicityUnwrapped, 123)
+
+		XCTAssertEqual(mappedObject?.uint, 123)
+		XCTAssertEqual(mappedObject?.uintOptional, 123)
+		XCTAssertEqual(mappedObject?.uintImplicityUnwrapped, 123)
+
+		XCTAssertEqual(mappedObject?.uint8, 123)
+		XCTAssertEqual(mappedObject?.uint8Optional, 123)
+		XCTAssertEqual(mappedObject?.uint8ImplicityUnwrapped, 123)
+
+		XCTAssertEqual(mappedObject?.uint16, 123)
+		XCTAssertEqual(mappedObject?.uint16Optional, 123)
+		XCTAssertEqual(mappedObject?.uint16ImplicityUnwrapped, 123)
+
+		XCTAssertEqual(mappedObject?.uint32, 123)
+		XCTAssertEqual(mappedObject?.uint32Optional, 123)
+		XCTAssertEqual(mappedObject?.uint32ImplicityUnwrapped, 123)
+
+		XCTAssertEqual(mappedObject?.uint64, 123)
+		XCTAssertEqual(mappedObject?.uint64Optional, 123)
+		XCTAssertEqual(mappedObject?.uint64ImplicityUnwrapped, 123)
 	}
 
 	func testMappingDoubleToJSON(){


### PR DESCRIPTION
## Background

#752 makes it available to map `Int` to every integer types. However, other integer type mappings such as `Int8` to `Int64` are not considered. This PR adds an availability to map every integer values to every integer values.

## Changes

* Change operator functions to cast values explicitly.
* Update test code to cover every integer types: `Int`, `Int8`, `Int16`, `Int32`, `Int64`, `UInt`, `UInt8`, `UInt16`, `UInt32`, `UInt64`.
* Parameterize test code in order to get rid of code redundant.

## Related Issues

* This is upgrade version of #752 
* This PR fixes #765

## Note

:warning: `IntegerOperator` doesn't take care of integer overflow and underflow.
