### PR TITLE
To help developers do something after Mapping has been completed.

### DIFF
--- a/Sources/ImmutableMappable.swift
+++ b/Sources/ImmutableMappable.swift
@@ -283,6 +283,7 @@ internal extension Mapper where N: BaseMappable {
 		if let klass = N.self as? ImmutableMappable.Type,
 			var object = try klass.init(map: map) as? N {
 			object.mapping(map: map)
+			object.doAfterMappingCompleted()
 			return object
 		}
 		

--- a/Sources/Mappable.swift
+++ b/Sources/Mappable.swift
@@ -46,6 +46,12 @@ public protocol StaticMappable: BaseMappable {
 	static func objectForMapping(map: Map) -> BaseMappable?
 }
 
+/// This Extension provides a function, that is called after mapping is completed.
+/// This can be used to perform after Mapping operations/manipulations of data, if required.
+public extension BaseMappable {
+	func doAfterMappingCompleted () {}
+}
+
 public extension BaseMappable {
 	
 	/// Initializes object from a JSON String

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -99,11 +99,13 @@ public final class Mapper<N: BaseMappable> {
 		if let klass = N.self as? StaticMappable.Type { // Check if object is StaticMappable
 			if var object = klass.objectForMapping(map: map) as? N {
 				object.mapping(map: map)
+				object.doAfterMappingCompleted()
 				return object
 			}
 		} else if let klass = N.self as? Mappable.Type { // Check if object is Mappable
 			if var object = klass.init(map: map) as? N {
 				object.mapping(map: map)
+				object.doAfterMappingCompleted()
 				return object
 			}
 		} else if N.self is ImmutableMappable.Type { // Check if object is ImmutableMappable

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -69,6 +69,7 @@ public final class Mapper<N: BaseMappable> {
 		var mutableObject = object
 		let map = Map(mappingType: .fromJSON, JSON: JSON, toObject: true, context: context, shouldIncludeNilValues: shouldIncludeNilValues)
 		mutableObject.mapping(map: map)
+		object.doAfterMappingCompleted()
 		return mutableObject
 	}
 


### PR DESCRIPTION
Have extended `BaseMappable Protocol` to include a function called `doAfterMappingCompleted`. This will help developers who want to perform operations after the Mapping has been completed.
