### PR TITLE
Increase NSDecimalNumberTransform precision

### DIFF
--- a/Sources/NSDecimalNumberTransform.swift
+++ b/Sources/NSDecimalNumberTransform.swift
@@ -37,8 +37,9 @@ open class NSDecimalNumberTransform: TransformType {
     open func transformFromJSON(_ value: Any?) -> NSDecimalNumber? {
         if let string = value as? String {
             return NSDecimalNumber(string: string)
-        }
-        if let double = value as? Double {
+		} else if let number = value as? NSNumber {
+			return NSDecimalNumber(decimal: number.decimalValue)
+		} else if let double = value as? Double {
             return NSDecimalNumber(floatLiteral: double)
         }
         return nil

--- a/Sources/NSDecimalNumberTransform.swift
+++ b/Sources/NSDecimalNumberTransform.swift
@@ -37,9 +37,9 @@ open class NSDecimalNumberTransform: TransformType {
     open func transformFromJSON(_ value: Any?) -> NSDecimalNumber? {
         if let string = value as? String {
             return NSDecimalNumber(string: string)
-		} else if let number = value as? NSNumber {
-			return NSDecimalNumber(decimal: number.decimalValue)
-		} else if let double = value as? Double {
+        } else if let number = value as? NSNumber {
+            return NSDecimalNumber(decimal: number.decimalValue)
+        } else if let double = value as? Double {
             return NSDecimalNumber(floatLiteral: double)
         }
         return nil

--- a/Tests/ObjectMapperTests/NSDecimalNumberTransformTests.swift
+++ b/Tests/ObjectMapperTests/NSDecimalNumberTransformTests.swift
@@ -36,11 +36,11 @@ class NSDecimalNumberTransformTests: XCTestCase {
     func testNSDecimalNumberTransform() {
         let int: Int = 11
         let double: Double = 11.11
-		/* Cannot use a float literal (eg: `let decimal: Decimal = 1.66`) as this transforms the value from 1.66 to 1.6599999999999995904 */
-		let decimal = Decimal(string: "1.66")!
+        /* Cannot use a float literal (eg: `let decimal: Decimal = 1.66`) as this transforms the value from 1.66 to 1.6599999999999995904 */
+        let decimal = Decimal(string: "1.66")!
         let intString = "11"
         let doubleString = "11.11"
-		let decimalString = "1.66"
+        let decimalString = "1.66"
         let JSONString = "{\"double\" : \(doubleString), \"int\" : \(intString), \"decimal\" : \(decimalString), \"intString\" : \"\(intString)\", \"doubleString\" : \"\(doubleString)\", \"decimalString\" : \"\(decimalString)\"}"
 
         let mappedObject = mapper.map(JSONString: JSONString)
@@ -48,13 +48,13 @@ class NSDecimalNumberTransformTests: XCTestCase {
         XCTAssertNotNil(mappedObject)
         XCTAssertEqual(mappedObject?.int, NSDecimalNumber(value: int))
         XCTAssertEqual(mappedObject?.double, NSDecimalNumber(value: double))
-		XCTAssertEqual(mappedObject?.decimal, NSDecimalNumber(decimal: decimal))
+        XCTAssertEqual(mappedObject?.decimal, NSDecimalNumber(decimal: decimal))
         XCTAssertEqual(mappedObject?.intString, NSDecimalNumber(string: intString))
         XCTAssertEqual(mappedObject?.doubleString, NSDecimalNumber(string: doubleString))
-		XCTAssertEqual(mappedObject?.decimalString, NSDecimalNumber(string: decimalString))
-		XCTAssertEqual(mappedObject?.int?.stringValue, intString)
-		XCTAssertEqual(mappedObject?.double?.stringValue, doubleString)
-		XCTAssertEqual(mappedObject?.decimal?.stringValue, decimalString)
+        XCTAssertEqual(mappedObject?.decimalString, NSDecimalNumber(string: decimalString))
+        XCTAssertEqual(mappedObject?.int?.stringValue, intString)
+        XCTAssertEqual(mappedObject?.double?.stringValue, doubleString)
+        XCTAssertEqual(mappedObject?.decimal?.stringValue, decimalString)
     }
 }
 
@@ -62,10 +62,10 @@ class NSDecimalNumberType: Mappable {
 
     var int: NSDecimalNumber?
     var double: NSDecimalNumber?
-	var decimal: NSDecimalNumber?
+    var decimal: NSDecimalNumber?
     var intString: NSDecimalNumber?
     var doubleString: NSDecimalNumber?
-	var decimalString: NSDecimalNumber?
+    var decimalString: NSDecimalNumber?
 
     init(){
 
@@ -78,9 +78,9 @@ class NSDecimalNumberType: Mappable {
     func mapping(map: Map) {
         int <- (map["int"], NSDecimalNumberTransform())
         double <- (map["double"], NSDecimalNumberTransform())
-		decimal <- (map["decimal"], NSDecimalNumberTransform())
+        decimal <- (map["decimal"], NSDecimalNumberTransform())
         intString <- (map["intString"], NSDecimalNumberTransform())
         doubleString <- (map["doubleString"], NSDecimalNumberTransform())
-		decimalString <- (map["decimalString"], NSDecimalNumberTransform())
+        decimalString <- (map["decimalString"], NSDecimalNumberTransform())
     }
 }

--- a/Tests/ObjectMapperTests/NSDecimalNumberTransformTests.swift
+++ b/Tests/ObjectMapperTests/NSDecimalNumberTransformTests.swift
@@ -36,17 +36,25 @@ class NSDecimalNumberTransformTests: XCTestCase {
     func testNSDecimalNumberTransform() {
         let int: Int = 11
         let double: Double = 11.11
-        let intString = "\(int)"
-        let doubleString = "\(double)"
-        let JSONString = "{\"double\" : \(double), \"int\" : \(int), \"intString\" : \"\(intString)\", \"doubleString\" : \"\(doubleString)\"}"
+		/* Cannot use a float literal (eg: `let decimal: Decimal = 1.66`) as this transforms the value from 1.66 to 1.6599999999999995904 */
+		let decimal = Decimal(string: "1.66")!
+        let intString = "11"
+        let doubleString = "11.11"
+		let decimalString = "1.66"
+        let JSONString = "{\"double\" : \(doubleString), \"int\" : \(intString), \"decimal\" : \(decimalString), \"intString\" : \"\(intString)\", \"doubleString\" : \"\(doubleString)\", \"decimalString\" : \"\(decimalString)\"}"
 
         let mappedObject = mapper.map(JSONString: JSONString)
 
         XCTAssertNotNil(mappedObject)
         XCTAssertEqual(mappedObject?.int, NSDecimalNumber(value: int))
         XCTAssertEqual(mappedObject?.double, NSDecimalNumber(value: double))
+		XCTAssertEqual(mappedObject?.decimal, NSDecimalNumber(decimal: decimal))
         XCTAssertEqual(mappedObject?.intString, NSDecimalNumber(string: intString))
         XCTAssertEqual(mappedObject?.doubleString, NSDecimalNumber(string: doubleString))
+		XCTAssertEqual(mappedObject?.decimalString, NSDecimalNumber(string: decimalString))
+		XCTAssertEqual(mappedObject?.int?.stringValue, intString)
+		XCTAssertEqual(mappedObject?.double?.stringValue, doubleString)
+		XCTAssertEqual(mappedObject?.decimal?.stringValue, decimalString)
     }
 }
 
@@ -54,8 +62,10 @@ class NSDecimalNumberType: Mappable {
 
     var int: NSDecimalNumber?
     var double: NSDecimalNumber?
+	var decimal: NSDecimalNumber?
     var intString: NSDecimalNumber?
     var doubleString: NSDecimalNumber?
+	var decimalString: NSDecimalNumber?
 
     init(){
 
@@ -68,7 +78,9 @@ class NSDecimalNumberType: Mappable {
     func mapping(map: Map) {
         int <- (map["int"], NSDecimalNumberTransform())
         double <- (map["double"], NSDecimalNumberTransform())
+		decimal <- (map["decimal"], NSDecimalNumberTransform())
         intString <- (map["intString"], NSDecimalNumberTransform())
         doubleString <- (map["doubleString"], NSDecimalNumberTransform())
+		decimalString <- (map["decimalString"], NSDecimalNumberTransform())
     }
 }


### PR DESCRIPTION
NSDecimalNumber currently eagerly transforms to floating point when presented with a JSON number which loses precision. This pull request solves that by using Foundation to do the conversion for us by attempting to cast the number to NSNumber first and grabbing the decimal value out of it.

I added tests which failed before the change and passed after, specifically: 
```
XCTAssertEqual(mappedObject?.decimal, NSDecimalNumber(decimal: decimal))
XCTAssertEqual failed: ("Optional(1.6599999999999995904)") is not equal to ("Optional(1.66)")

XCTAssertEqual(mappedObject?.decimal?.stringValue, decimalString)
XCTAssertEqual failed: ("Optional("1.6599999999999995904")") is not equal to ("Optional("1.66")")
```

This should also resolve #776.