### PR TITLE
Add support to ImmutableMappable can become a property of Mappable

### DIFF
--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -106,8 +106,22 @@ public final class Mapper<N: BaseMappable> {
 				object.mapping(map: map)
 				return object
 			}
-		} else if N.self is ImmutableMappable.Type { // Check if object is ImmutableMappable
-			assert(false, "'ImmutableMappable' type requires throwing version of function \(#function)  - use 'try' before \(#function)")
+		} else if let klass = N.self as? ImmutableMappable.Type { // Check if object is ImmutableMappable
+			do {
+				return try klass.init(map: map) as? N
+			} catch let error {
+				#if DEBUG
+				let exception: NSException
+				if let mapError = error as? MapError {
+					exception = NSException(name: .init(rawValue: "MapError"), reason: mapError.description, userInfo: nil)
+				} else {
+					exception = NSException(name: .init(rawValue: "ImmutableMappableError"), reason: error.localizedDescription, userInfo: nil)
+				}
+				exception.raise()
+				#else
+				NSLog("\(error)")
+				#endif
+			}
 		} else {
 			// Ensure BaseMappable is not implemented directly
 			assert(false, "BaseMappable should not be implemented directly. Please implement Mappable, StaticMappable or ImmutableMappable")

--- a/Tests/ObjectMapperTests/ImmutableTests.swift
+++ b/Tests/ObjectMapperTests/ImmutableTests.swift
@@ -297,6 +297,31 @@ class ImmutableObjectTests: XCTestCase {
 		XCTAssertThrowsError(try Mapper<Struct>().mapArrayOfArrays(JSONObject: JSONArray))
 	}
 
+	func testAsPropertyOfMappable() {
+		struct ImmutableObject: ImmutableMappable {
+			let value: String
+			init(map: Map) throws {
+				self.value = try map.value("value")
+			}
+		}
+
+		struct Object: Mappable {
+			var immutable: ImmutableObject!
+			init?(map: Map) {}
+			mutating func mapping(map: Map) {
+				self.immutable <- map["immutable"]
+			}
+		}
+
+		let json: [String: Any] = [
+			"immutable": [
+				"value": "Hello"
+			]
+		]
+		let object = Mapper<Object>().map(JSON: json)
+		XCTAssertEqual(object?.immutable?.value, "Hello")
+	}
+
 }
 
 struct Struct {


### PR DESCRIPTION
## Background

`ImmutableMappable` was originally designed to not be used as property of the `Mappable`. It's because the `map()` function on `BaseMappable` cannot throw an error if `ImmutableMappable` is not correctly mapped. But this behavior can occur many confusions because there's no compiler level warnings.

I think `NSException` can raise an runtime exception if there's an error on mapping. It's important to make application safe, exceptions are only raised in debug environment.

Any discussions are welcomed 😃

## Related Issues

* This PR resolves #668
