### PR TITLE
Insert an ‘assert’, which may point out Generic Type parameter’s unconformity when debugging or testing.

### DIFF
--- a/Sources/IntegerOperators.swift
+++ b/Sources/IntegerOperators.swift
@@ -103,7 +103,9 @@ private func toSignedInteger<T: SignedInteger>(_ value: Any?) -> T? {
 	case let x as UInt16: max = .init(x)
 	case let x as UInt32: max = .init(x)
 	case let x as UInt64: max = .init(x)
-	default: return nil
+	default:
+		assert(false, "Generic Type is not the same type, return 'T?' fail, please check your parameter type")
+		return nil
 	}
 	return T.init(max)
 }
@@ -123,7 +125,9 @@ private func toUnsignedInteger<T: UnsignedInteger>(_ value: Any?) -> T? {
 	case let x as UInt16: max = .init(x)
 	case let x as UInt32: max = .init(x)
 	case let x as UInt64: max = .init(x)
-	default: return nil
+	default:
+		assert(false, "Generic Type is not the same type, return 'T?' fail, please check your parameter type")
+		return nil
 	}
 	return T.init(max)
 }

--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -120,7 +120,9 @@ public final class Map {
 	}
 	
 	public func value<T>() -> T? {
-		return currentValue as? T
+		let value = currentValue as? T
+		assert(!(currentValue != nil && value == nil), "Generic Type is not the same type, 'as? T' fail. please check your parameters type")
+		return value
 	}
 	
 }

--- a/Sources/TransformOf.swift
+++ b/Sources/TransformOf.swift
@@ -39,6 +39,7 @@ open class TransformOf<ObjectType, JSONType>: TransformType {
 	}
 
 	open func transformFromJSON(_ value: Any?) -> ObjectType? {
+		assert(!(value != nil && value as? JSONType == nil), "JSONType error, please check your definition")
 		return fromJSON(value as? JSONType)
 	}
 


### PR DESCRIPTION
Because I'm unfamiliar with the whole ObjectMapper, I only deal a part of the situation of operators' usage. I will do more later.