### PR TITLE
Abstract map key to MapKeyConvertible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,16 +35,16 @@ script:
 
   # Build Framework in Debug and Run Tests if specified
   - if [ $RUN_TESTS == "YES" ]; then
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
+      travis_retry xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
     else
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
+      travis_retry xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
     fi
 
   # Build Framework in Release and Run Tests if specified
   - if [ $RUN_TESTS == "YES" ]; then
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
+      travis_retry xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
     else
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
+      travis_retry xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
     fi
 
 notifications:

--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		030E75F61E588BF80027D94A /* IntegerOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038F0A021E55FE2400613148 /* IntegerOperators.swift */; };
 		030E75F71E588BFC0027D94A /* IntegerOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038F0A021E55FE2400613148 /* IntegerOperators.swift */; };
 		038F0A031E55FE2400613148 /* IntegerOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038F0A021E55FE2400613148 /* IntegerOperators.swift */; };
+		2C58BDAA1E9409F200EF5401 /* MapKeyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58BDA91E9409F200EF5401 /* MapKeyConvertible.swift */; };
+		2C58BDAC1E940C6700EF5401 /* MapKeyConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58BDAB1E940C6700EF5401 /* MapKeyConvertibleTests.swift */; };
+		2C58BDAD1E940C6700EF5401 /* MapKeyConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58BDAB1E940C6700EF5401 /* MapKeyConvertibleTests.swift */; };
+		2C58BDAE1E940C6700EF5401 /* MapKeyConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58BDAB1E940C6700EF5401 /* MapKeyConvertibleTests.swift */; };
 		37AFD9B91AAD191C00AB59B5 /* CustomDateFormatTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */; };
 		3BAD2C0C1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
 		3BAD2C0D1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
@@ -222,6 +226,8 @@
 		030114A81D95187600FBFD4F /* ImmutableMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmutableMappable.swift; sourceTree = "<group>"; };
 		030114AA1D95197100FBFD4F /* ImmutableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImmutableTests.swift; path = ObjectMapperTests/ImmutableTests.swift; sourceTree = "<group>"; };
 		038F0A021E55FE2400613148 /* IntegerOperators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegerOperators.swift; sourceTree = "<group>"; };
+		2C58BDA91E9409F200EF5401 /* MapKeyConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapKeyConvertible.swift; sourceTree = "<group>"; };
+		2C58BDAB1E940C6700EF5401 /* MapKeyConvertibleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MapKeyConvertibleTests.swift; path = ObjectMapperTests/MapKeyConvertibleTests.swift; sourceTree = "<group>"; };
 		37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomDateFormatTransform.swift; sourceTree = "<group>"; };
 		3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Mappable.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MappableExtensionsTests.swift; path = ObjectMapperTests/MappableExtensionsTests.swift; sourceTree = "<group>"; };
@@ -400,6 +406,7 @@
 				6AF148831D999E31002BEA2C /* GenericObjectsTests.swift */,
 				6A715C491D05B1FA0054AD62 /* IgnoreNilTests.swift */,
 				030114AA1D95197100FBFD4F /* ImmutableTests.swift */,
+				2C58BDAB1E940C6700EF5401 /* MapKeyConvertibleTests.swift */,
 				6A442CA01CE251F100AB4F1F /* MapContextTests.swift */,
 				3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */,
 				891804CC1C122AF000E5C3EE /* MappableTypesWithTransformsTests.swift */,
@@ -427,6 +434,7 @@
 		6AAC8FC219F048FE00E7A677 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				2C58BDA91E9409F200EF5401 /* MapKeyConvertible.swift */,
 				6ACB15D11BC7F1D0006C029C /* Map.swift */,
 				6AF148871D99A25B002BEA2C /* MapError.swift */,
 				3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */,
@@ -787,6 +795,7 @@
 				6A442CA31CE251F100AB4F1F /* MapContextTests.swift in Sources */,
 				6AA1F66B1BE94687006EF513 /* ClassClusterTests.swift in Sources */,
 				6AECC9E81D79E29100222E7A /* DictionaryTransformTests.swift in Sources */,
+				2C58BDAE1E940C6700EF5401 /* MapKeyConvertibleTests.swift in Sources */,
 				6AA1F66C1BE94687006EF513 /* PerformanceTests.swift in Sources */,
 				6AC692411BE3FD45004C119A /* BasicTypes.swift in Sources */,
 				6A0BF2011C0B53470083D1AF /* ToObjectTests.swift in Sources */,
@@ -851,6 +860,7 @@
 				CD71C8C11A7218AD009D4161 /* TransformOf.swift in Sources */,
 				030114A91D95187600FBFD4F /* ImmutableMappable.swift in Sources */,
 				6A6C54D019FE8DB600239454 /* URLTransform.swift in Sources */,
+				2C58BDAA1E9409F200EF5401 /* MapKeyConvertible.swift in Sources */,
 				038F0A031E55FE2400613148 /* IntegerOperators.swift in Sources */,
 				6A51372C1AADDE2700B82516 /* DateFormatterTransform.swift in Sources */,
 				6AAC8FCE19F048FE00E7A677 /* Mapper.swift in Sources */,
@@ -874,6 +884,7 @@
 				6A442CA11CE251F100AB4F1F /* MapContextTests.swift in Sources */,
 				6A6AEB961A93874F002573D3 /* BasicTypesTestsFromJSON.swift in Sources */,
 				6AECC9E61D79E29100222E7A /* DictionaryTransformTests.swift in Sources */,
+				2C58BDAC1E940C6700EF5401 /* MapKeyConvertibleTests.swift in Sources */,
 				6A0BF1FF1C0B53470083D1AF /* ToObjectTests.swift in Sources */,
 				CD44374D1AAE9C1100A271BA /* NestedKeysTests.swift in Sources */,
 				6A3774341A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift in Sources */,
@@ -931,6 +942,7 @@
 				6A442CA21CE251F100AB4F1F /* MapContextTests.swift in Sources */,
 				6AA1F66D1BE9468D006EF513 /* NestedArrayTests.swift in Sources */,
 				6AECC9E71D79E29100222E7A /* DictionaryTransformTests.swift in Sources */,
+				2C58BDAD1E940C6700EF5401 /* MapKeyConvertibleTests.swift in Sources */,
 				6A412A181BAC830B001C3F67 /* ClassClusterTests.swift in Sources */,
 				CD1603261AC02480000CD69A /* BasicTypesTestsFromJSON.swift in Sources */,
 				6A0BF2001C0B53470083D1AF /* ToObjectTests.swift in Sources */,

--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		2C58BDAC1E940C6700EF5401 /* MapKeyConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58BDAB1E940C6700EF5401 /* MapKeyConvertibleTests.swift */; };
 		2C58BDAD1E940C6700EF5401 /* MapKeyConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58BDAB1E940C6700EF5401 /* MapKeyConvertibleTests.swift */; };
 		2C58BDAE1E940C6700EF5401 /* MapKeyConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58BDAB1E940C6700EF5401 /* MapKeyConvertibleTests.swift */; };
+		2C58BDEF1E94BD6000EF5401 /* MapKeyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58BDA91E9409F200EF5401 /* MapKeyConvertible.swift */; };
+		2C58BDF01E94BD6100EF5401 /* MapKeyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58BDA91E9409F200EF5401 /* MapKeyConvertible.swift */; };
+		2C58BDF11E94BD6100EF5401 /* MapKeyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58BDA91E9409F200EF5401 /* MapKeyConvertible.swift */; };
 		37AFD9B91AAD191C00AB59B5 /* CustomDateFormatTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */; };
 		3BAD2C0C1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
 		3BAD2C0D1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
@@ -780,6 +783,7 @@
 				797FEDD01DAB856000E31F75 /* HexColorTransform.swift in Sources */,
 				6AF1488B1D99A25B002BEA2C /* MapError.swift in Sources */,
 				C135CABC1D7631DC00BA9338 /* DataTransform.swift in Sources */,
+				2C58BDF11E94BD6100EF5401 /* MapKeyConvertible.swift in Sources */,
 				030114B11D951A7500FBFD4F /* ImmutableMappable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -838,6 +842,7 @@
 				797FEDCF1DAB855F00E31F75 /* HexColorTransform.swift in Sources */,
 				6AF1488A1D99A25B002BEA2C /* MapError.swift in Sources */,
 				C135CABB1D7631DB00BA9338 /* DataTransform.swift in Sources */,
+				2C58BDF01E94BD6100EF5401 /* MapKeyConvertible.swift in Sources */,
 				030114B01D951A7100FBFD4F /* ImmutableMappable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -927,6 +932,7 @@
 				797FEDCE1DAB855F00E31F75 /* HexColorTransform.swift in Sources */,
 				6AF148891D99A25B002BEA2C /* MapError.swift in Sources */,
 				CD16031B1AC02451000CD69A /* FromJSON.swift in Sources */,
+				2C58BDEF1E94BD6000EF5401 /* MapKeyConvertible.swift in Sources */,
 				C135CABA1D7631DB00BA9338 /* DataTransform.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/ImmutableMappable.swift
+++ b/Sources/ImmutableMappable.swift
@@ -54,15 +54,15 @@ public extension ImmutableMappable {
 
 public extension Map {
 
-	fileprivate func currentValue(for key: String, nested: Bool? = nil, delimiter: String = ".") -> Any? {
-		let isNested = nested ?? key.contains(delimiter)
+	fileprivate func currentValue(for key: MapKeyConvertible, nested: Bool? = nil, delimiter: String = ".") -> Any? {
+		let isNested = nested ?? key.asMapKey().contains(delimiter)
 		return self[key, nested: isNested, delimiter: delimiter].currentValue
 	}
 	
 	// MARK: Basic
 
 	/// Returns a value or throws an error.
-	public func value<T>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
+	public func value<T>(_ key: MapKeyConvertible, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let value = currentValue as? T else {
 			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '\(T.self)'", file: file, function: function, line: line)
@@ -71,7 +71,7 @@ public extension Map {
 	}
 
 	/// Returns a transformed value or throws an error.
-	public func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> Transform.Object {
+	public func value<Transform: TransformType>(_ key: MapKeyConvertible, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> Transform.Object {
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let value = transform.transformFromJSON(currentValue) else {
 			throw MapError(key: key, currentValue: currentValue, reason: "Cannot transform to '\(Transform.Object.self)' using \(transform)", file: file, function: function, line: line)
@@ -80,14 +80,14 @@ public extension Map {
 	}
 	
 	/// Returns a RawRepresentable type or throws an error.
-	public func value<T: RawRepresentable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
+	public func value<T: RawRepresentable>(_ key: MapKeyConvertible, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
 		return try self.value(key, nested: nested, delimiter: delimiter, using: EnumTransform(), file: file, function: function, line: line)
 	}
 
 	// MARK: BaseMappable
 
 	/// Returns a `BaseMappable` object or throws an error.
-	public func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
+	public func value<T: BaseMappable>(_ key: MapKeyConvertible, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let JSONObject = currentValue else {
 			throw MapError(key: key, currentValue: currentValue, reason: "Found unexpected nil value", file: file, function: function, line: line)
@@ -98,7 +98,7 @@ public extension Map {
 	// MARK: [BaseMappable]
 
 	/// Returns a `[BaseMappable]` or throws an error.
-	public func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [T] {
+	public func value<T: BaseMappable>(_ key: MapKeyConvertible, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [T] {
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let jsonArray = currentValue as? [Any] else {
 			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '[Any]'", file: file, function: function, line: line)
@@ -109,7 +109,7 @@ public extension Map {
 	}
 
 	/// Returns a `[BaseMappable]` using transform or throws an error.
-	public func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [Transform.Object] {
+	public func value<Transform: TransformType>(_ key: MapKeyConvertible, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [Transform.Object] {
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let jsonArray = currentValue as? [Any] else {
 			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '[Any]'", file: file, function: function, line: line)
@@ -125,7 +125,7 @@ public extension Map {
 	// MARK: [String: BaseMappable]
 
 	/// Returns a `[String: BaseMappable]` or throws an error.
-	public func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [String: T] {
+	public func value<T: BaseMappable>(_ key: MapKeyConvertible, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [String: T] {
 		
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let jsonDictionary = currentValue as? [String: Any] else {
@@ -139,7 +139,7 @@ public extension Map {
 	}
 
 	/// Returns a `[String: BaseMappable]` using transform or throws an error.
-	public func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [String: Transform.Object] {
+	public func value<Transform: TransformType>(_ key: MapKeyConvertible, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [String: Transform.Object] {
 		
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let jsonDictionary = currentValue as? [String: Any] else {
@@ -157,7 +157,7 @@ public extension Map {
 	
 	// MARK: [[BaseMappable]]
 	/// Returns a `[[BaseMappable]]` or throws an error.
-	public func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [[T]] {
+	public func value<T: BaseMappable>(_ key: MapKeyConvertible, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [[T]] {
 		
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let json2DArray = currentValue as? [[Any]] else {
@@ -171,7 +171,7 @@ public extension Map {
 	}
 	
 	/// Returns a `[[BaseMappable]]` using transform or throws an error.
-	public func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [[Transform.Object]] {
+	public func value<Transform: TransformType>(_ key: MapKeyConvertible, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [[Transform.Object]] {
 		
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let json2DArray = currentValue as? [[Any]] else {

--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -41,7 +41,7 @@ public final class Map {
 	public internal(set) var JSON: [String: Any] = [:]
 	public internal(set) var isKeyPresent = false
 	public internal(set) var currentValue: Any?
-	public internal(set) var currentKey: String?
+	public internal(set) var currentKey: MapKeyConvertible?
 	var keyIsNested = false
 	public internal(set) var nestedKeyDelimiter: String = "."
 	public var context: MapContext?
@@ -60,38 +60,38 @@ public final class Map {
 	
 	/// Sets the current mapper value and key.
 	/// The Key paramater can be a period separated string (ex. "distance.value") to access sub objects.
-	public subscript(key: String) -> Map {
+	public subscript(key: MapKeyConvertible) -> Map {
 		// save key and value associated to it
 		return self[key, delimiter: ".", ignoreNil: false]
 	}
 	
-	public subscript(key: String, delimiter delimiter: String) -> Map {
-		let nested = key.contains(delimiter)
+	public subscript(key: MapKeyConvertible, delimiter delimiter: String) -> Map {
+		let nested = key.asMapKey().contains(delimiter)
 		return self[key, nested: nested, delimiter: delimiter, ignoreNil: false]
 	}
 	
-	public subscript(key: String, nested nested: Bool) -> Map {
+	public subscript(key: MapKeyConvertible, nested nested: Bool) -> Map {
 		return self[key, nested: nested, delimiter: ".", ignoreNil: false]
 	}
 	
-	public subscript(key: String, nested nested: Bool, delimiter delimiter: String) -> Map {
+	public subscript(key: MapKeyConvertible, nested nested: Bool, delimiter delimiter: String) -> Map {
 		return self[key, nested: nested, delimiter: delimiter, ignoreNil: false]
 	}
 	
-	public subscript(key: String, ignoreNil ignoreNil: Bool) -> Map {
+	public subscript(key: MapKeyConvertible, ignoreNil ignoreNil: Bool) -> Map {
 		return self[key, delimiter: ".", ignoreNil: ignoreNil]
 	}
 	
-	public subscript(key: String, delimiter delimiter: String, ignoreNil ignoreNil: Bool) -> Map {
-		let nested = key.contains(delimiter)
+	public subscript(key: MapKeyConvertible, delimiter delimiter: String, ignoreNil ignoreNil: Bool) -> Map {
+		let nested = key.asMapKey().contains(delimiter)
 		return self[key, nested: nested, delimiter: delimiter, ignoreNil: ignoreNil]
 	}
 	
-	public subscript(key: String, nested nested: Bool, ignoreNil ignoreNil: Bool) -> Map {
+	public subscript(key: MapKeyConvertible, nested nested: Bool, ignoreNil ignoreNil: Bool) -> Map {
 		return self[key, nested: nested, delimiter: ".", ignoreNil: ignoreNil]
 	}
 	
-	public subscript(key: String, nested nested: Bool, delimiter delimiter: String, ignoreNil ignoreNil: Bool) -> Map {
+	public subscript(key: MapKeyConvertible, nested nested: Bool, delimiter delimiter: String, ignoreNil ignoreNil: Bool) -> Map {
 		// save key and value associated to it
 		currentKey = key
 		keyIsNested = nested
@@ -101,13 +101,13 @@ public final class Map {
 			// check if a value exists for the current key
 			// do this pre-check for performance reasons
 			if nested == false {
-				let object = JSON[key]
+				let object = JSON[key.asMapKey()]
 				let isNSNull = object is NSNull
 				isKeyPresent = isNSNull ? true : object != nil
 				currentValue = isNSNull ? nil : object
 			} else {
 				// break down the components of the key that are separated by .
-				(isKeyPresent, currentValue) = valueFor(ArraySlice(key.components(separatedBy: delimiter)), dictionary: JSON)
+				(isKeyPresent, currentValue) = valueFor(ArraySlice(key.asMapKey().components(separatedBy: delimiter)), dictionary: JSON)
 			}
 			
 			// update isKeyPresent if ignoreNil is true

--- a/Sources/MapError.swift
+++ b/Sources/MapError.swift
@@ -29,14 +29,14 @@
 import Foundation
 
 public struct MapError: Error {
-	public var key: String?
+	public var key: MapKeyConvertible?
 	public var currentValue: Any?
 	public var reason: String?
 	public var file: StaticString?
 	public var function: StaticString?
 	public var line: UInt?
 	
-	public init(key: String?, currentValue: Any?, reason: String?, file: StaticString? = nil, function: StaticString? = nil, line: UInt? = nil) {
+	public init(key: MapKeyConvertible?, currentValue: Any?, reason: String?, file: StaticString? = nil, function: StaticString? = nil, line: UInt? = nil) {
 		self.key = key
 		self.currentValue = currentValue
 		self.reason = reason
@@ -58,7 +58,7 @@ extension MapError: CustomStringConvertible {
 		let info: [(String, Any?)] = [
 			("- reason", reason),
 			("- location", location),
-			("- key", key),
+			("- key", key?.asMapKey()),
 			("- currentValue", currentValue),
 			]
 		let infoString = info.map { "\($0): \($1 ?? "nil")" }.joined(separator: "\n")

--- a/Sources/MapKeyConvertible.swift
+++ b/Sources/MapKeyConvertible.swift
@@ -1,0 +1,48 @@
+//
+//  MapKeyConvertible.swift
+//  ObjectMapper
+//
+//  Created by Tristan Himmelman on 2015-10-09.
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2014-2016 Hearst
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// Protocol key types implement
+public protocol MapKeyConvertible {
+	func asMapKey() -> String
+}
+
+/// Extend String to be MapKeyConvertible
+extension String: MapKeyConvertible {
+	public func asMapKey() -> String {
+		return self
+	}
+}
+
+/// Extend RawRepresentable to be MapKeyConvertible
+extension RawRepresentable {
+	public func asMapKey() -> String {
+		return "\(self)"
+	}
+}

--- a/Sources/ToJSON.swift
+++ b/Sources/ToJSON.swift
@@ -32,12 +32,12 @@ private func setValue(_ value: Any, map: Map) {
 	setValue(value, key: map.currentKey!, checkForNestedKeys: map.keyIsNested, delimiter: map.nestedKeyDelimiter, dictionary: &map.JSON)
 }
 
-private func setValue(_ value: Any, key: String, checkForNestedKeys: Bool, delimiter: String, dictionary: inout [String : Any]) {
+private func setValue(_ value: Any, key: MapKeyConvertible, checkForNestedKeys: Bool, delimiter: String, dictionary: inout [String : Any]) {
 	if checkForNestedKeys {
-		let keyComponents = ArraySlice(key.components(separatedBy: delimiter).filter { !$0.isEmpty }.map { $0.characters })
+		let keyComponents = ArraySlice(key.asMapKey().components(separatedBy: delimiter).filter { !$0.isEmpty }.map { $0.characters })
 		setValue(value, forKeyPathComponents: keyComponents, dictionary: &dictionary)
 	} else {
-		dictionary[key] = value
+		dictionary[key.asMapKey()] = value
 	}
 }
 

--- a/Tests/ObjectMapperTests/MapKeyConvertibleTests.swift
+++ b/Tests/ObjectMapperTests/MapKeyConvertibleTests.swift
@@ -1,0 +1,49 @@
+//
+//  MapKeyConvertibleTests.swift
+//  ObjectMapper
+//
+//  Created by Mark Woollard on 04/04/2017.
+//  Copyright © 2017 hearst. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import ObjectMapper
+
+class MapKeyConvertibleTests: XCTestCase {
+	
+	let JSON: [String: Any] = [
+		"prop1": "MapKeyConvertible",
+		"prop2": 255,
+		"prop3": true,
+	]
+	
+	enum Keys: String, MapKeyConvertible {
+		case prop1
+		case prop2
+		case prop3
+	}
+	
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func test() {
+		let map = Map(mappingType: .fromJSON, JSON: JSON)
+		
+		let prop1: String = try! map.value(Keys.prop1)
+		let prop2: Int = try! map.value(Keys.prop2)
+		let prop3: Bool = try! map.value(Keys.prop3)
+		
+		XCTAssertEqual(prop1, "MapKeyConvertible")
+		XCTAssertEqual(prop2, 255)
+		XCTAssertEqual(prop3, true)
+    }
+	
+}


### PR DESCRIPTION
It'd be great if you would consider this PR which abstracts the mapping key to a new protocol `MapKeyConvertible`. `String` is extended to implement `MapKeyConvertible` so `String` keys can be used as before and thus breaking changes to existing users. `RawRepresentible` is also extended to implement `MapKeyConvertible` and so you can define your keys as an enum which is my main motivation behind the change:
```
enum Keys: String, MapKeyConvertible {
    case key1
    case key2
}
```
Having done this you can then use the enum as mapping key throughout `ObjectMapper`, a quick example:
```
    let value: String = try map.value(Keys.key1)
    let value: Int = try map.value(Keys.key2)
```
Let me know what you think :-)
Kind regards
Mark