### PR TITLE
Serious CocoaPod bug:  wrong boolean value specified in ObjectMapper.podspec 

### DIFF
--- a/ObjectMapper.podspec
+++ b/ObjectMapper.podspec
@@ -11,12 +11,12 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
-  
-  
+
+
   s.pod_target_xcconfig = {
     'SWIFT_VERSION' => '3.0',
   }
-  
-  s.requires_arc = 'true'
+
+  s.requires_arc = true
   s.source_files = 'Sources/**/*.swift'
 end


### PR DESCRIPTION
I normally use Carthage, but for a project i had to use Cocoapods, found an issue:

I found a serious bug in the Cocoapod spec file, the 
```
 s.requires_arc = true
```

had a typo it can't have quotes. because it will import the library now as a library with **No** arc required.

I created first this bug at Cocoapods until realized this issue:

https://github.com/CocoaPods/CocoaPods/issues/6701



