### PR TITLE
no reason to return optional when map arrays

### DIFF
--- a/Sources/Mappable.swift
+++ b/Sources/Mappable.swift
@@ -89,12 +89,9 @@ public extension Array where Element: BaseMappable {
 	}
 	
 	/// Initialize Array from a JSON Array
-	public init?(JSONArray: [[String: Any]], context: MapContext? = nil) {
-		if let obj: [Element] = Mapper(context: context).mapArray(JSONArray: JSONArray) {
-			self = obj
-		} else {
-			return nil
-		}
+	public init(JSONArray: [[String: Any]], context: MapContext? = nil) {
+		let obj: [Element] = Mapper(context: context).mapArray(JSONArray: JSONArray)
+		self = obj
 	}
 	
 	/// Returns the JSON Array

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -159,7 +159,7 @@ public final class Mapper<N: BaseMappable> {
 	}
 	
 	/// Maps an array of JSON dictionary to an array of Mappable objects
-	public func mapArray(JSONArray: [[String: Any]]) -> [N]? {
+	public func mapArray(JSONArray: [[String: Any]]) -> [N] {
 		// map every element in JSON array to type N
 		let result = JSONArray.flatMap(map)
 		return result
@@ -242,9 +242,8 @@ public final class Mapper<N: BaseMappable> {
 		if let JSONArray = JSONObject as? [[[String: Any]]] {
 			var objectArray = [[N]]()
 			for innerJSONArray in JSONArray {
-				if let array = mapArray(JSONArray: innerJSONArray){
-					objectArray.append(array)
-				}
+				let array = mapArray(JSONArray: innerJSONArray)
+				objectArray.append(array)
 			}
 			
 			if objectArray.isEmpty == false {

--- a/Tests/ObjectMapperTests/ClassClusterTests.swift
+++ b/Tests/ObjectMapperTests/ClassClusterTests.swift
@@ -68,14 +68,13 @@ class ClassClusterTests: XCTestCase {
 		let carName = "Honda"
 		let JSON = [["name": carName, "type": "car"], ["type": "bus"], ["type": "vehicle"]]
 		
-		if let vehicles = Mapper<Vehicle>().mapArray(JSONArray: JSON){
-			XCTAssertNotNil(vehicles)
-			XCTAssertTrue(vehicles.count == 3)
-			XCTAssertNotNil(vehicles[0] as? Car)
-			XCTAssertNotNil(vehicles[1] as? Bus)
-			XCTAssertNotNil(vehicles[2])
-			XCTAssertEqual((vehicles[0] as? Car)?.name, carName)
-		}
+		let vehicles = Mapper<Vehicle>().mapArray(JSONArray: JSON)
+		XCTAssertNotNil(vehicles)
+		XCTAssertTrue(vehicles.count == 3)
+		XCTAssertNotNil(vehicles[0] as? Car)
+		XCTAssertNotNil(vehicles[1] as? Bus)
+		XCTAssertNotNil(vehicles[2])
+		XCTAssertEqual((vehicles[0] as? Car)?.name, carName)
 	}
 }
 

--- a/Tests/ObjectMapperTests/MappableExtensionsTests.swift
+++ b/Tests/ObjectMapperTests/MappableExtensionsTests.swift
@@ -86,7 +86,7 @@ class MappableExtensionsTests: XCTestCase {
 	
 	func testArrayToJSONAndBack() {
 		let mapped = [TestMappable](JSONArray: [testMappable].toJSON())
-		XCTAssertEqual(mapped!, [testMappable])
+		XCTAssertEqual(mapped, [testMappable])
 	}
 	
 	func testSetInitFailsWithEmptyString() {


### PR DESCRIPTION
flatMap (called inside of mapArray method) does not return an optional value, so there’s no reason to return optional