### PR TITLE
Change AnyObject to Any in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ class User: Mappable {
     var username: String?
     var age: Int?
     var weight: Double!
-    var array: [AnyObject]?
-    var dictionary: [String : AnyObject] = [:]
+    var array: [Any]?
+    var dictionary: [String : Any] = [:]
     var bestFriend: User?                       // Nested User object
     var friends: [User]?                        // Array of Users
     var birthday: Date?
@@ -107,8 +107,8 @@ ObjectMapper can map classes composed of the following types:
 - `Float`
 - `String`
 - `RawRepresentable` (Enums)
-- `Array<AnyObject>`
-- `Dictionary<String, AnyObject>`
+- `Array<Any>`
+- `Dictionary<String, Any>`
 - `Object<T: Mappable>`
 - `Array<T: Mappable>`
 - `Array<Array<T: Mappable>>`


### PR DESCRIPTION
In Swift 3.0 Any includes value types (like Int, String, etc) so it's better than AnyObject