### PR TITLE
Map array of raw representables for ImmutableMappable

### DIFF
--- a/Sources/ImmutableMappable.swift
+++ b/Sources/ImmutableMappable.swift
@@ -83,6 +83,11 @@ public extension Map {
 	public func value<T: RawRepresentable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
 		return try self.value(key, nested: nested, delimiter: delimiter, using: EnumTransform(), file: file, function: function, line: line)
 	}
+	
+	/// Returns a `[RawRepresentable]` type or throws an error.
+	public func value<T: RawRepresentable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [T] {
+		return try self.value(key, nested: nested, delimiter: delimiter, using: EnumTransform(), file: file, function: function, line: line)
+	}
 
 	// MARK: BaseMappable
 

--- a/Tests/ObjectMapperTests/ImmutableTests.swift
+++ b/Tests/ObjectMapperTests/ImmutableTests.swift
@@ -78,18 +78,23 @@ class ImmutableObjectTests: XCTestCase {
 		// RawRepresentable
 		"prop27a": NSNumber(value: 0),
 		"prop27b": NSNumber(value: 1000),
+		"prop27c": [NSNumber(value: 0), NSNumber(value: 1000)],
 
 		"prop28a": Int(0),
 		"prop28b": Int(255),
+		"prop28c": [Int(0), Int(255)],
 
 		"prop29a": Double(0),
 		"prop29b": Double(100),
+		"prop29c": [Double(0), Double(100)],
 
 		"prop30a": Float(0),
 		"prop30b": Float(100),
+		"prop30c": [Float(0), Float(100)],
 		
 		"prop31a": "String A",
 		"prop31b": "String B",
+		"prop31c": ["String A", "String B"],
 		
 		// [[String]]
 		"prop32": [["prop32"]],
@@ -158,18 +163,23 @@ class ImmutableObjectTests: XCTestCase {
 		
 		XCTAssertEqual(immutable.prop27a.rawValue, Int64Enum.a.rawValue)
 		XCTAssertEqual(immutable.prop27b.rawValue, Int64Enum.b.rawValue)
+		XCTAssertEqual(immutable.prop27c, [Int64Enum.a, Int64Enum.b])
 		
 		XCTAssertEqual(immutable.prop28a.rawValue, IntEnum.a.rawValue)
 		XCTAssertEqual(immutable.prop28b.rawValue, IntEnum.b.rawValue)
+		XCTAssertEqual(immutable.prop28c, [IntEnum.a, IntEnum.b])
 		
 		XCTAssertEqual(immutable.prop29a.rawValue, DoubleEnum.a.rawValue)
 		XCTAssertEqual(immutable.prop29b.rawValue, DoubleEnum.b.rawValue)
+		XCTAssertEqual(immutable.prop29c, [DoubleEnum.a, DoubleEnum.b])
 		
 		XCTAssertEqual(immutable.prop30a.rawValue, FloatEnum.a.rawValue)
 		XCTAssertEqual(immutable.prop30b.rawValue, FloatEnum.b.rawValue)
+		XCTAssertEqual(immutable.prop30c, [FloatEnum.a, FloatEnum.b])
 		
 		XCTAssertEqual(immutable.prop31a.rawValue, StringEnum.A.rawValue)
 		XCTAssertEqual(immutable.prop31b.rawValue, StringEnum.B.rawValue)
+		XCTAssertEqual(immutable.prop31c, [StringEnum.A, StringEnum.B])
 		
 		XCTAssertEqual(immutable.prop32[0][0], "prop32_TRANSFORMED")
 		XCTAssertEqual(immutable.prop33![0][0], "prop33_TRANSFORMED")
@@ -363,18 +373,23 @@ struct Struct {
 	// RawRepresentable
 	let prop27a: Int64Enum
 	let prop27b: Int64Enum
+	let prop27c: [Int64Enum]
 	
 	let prop28a: IntEnum
 	let prop28b: IntEnum
+	let prop28c: [IntEnum]
 	
 	let prop29a: DoubleEnum
 	let prop29b: DoubleEnum
+	let prop29c: [DoubleEnum]
 	
 	let prop30a: FloatEnum
 	let prop30b: FloatEnum
+	let prop30c: [FloatEnum]
 	
 	let prop31a: StringEnum
 	let prop31b: StringEnum
+	let prop31c: [StringEnum]
 	
 	let prop32: [[String]]
 	let prop33: [[String]]?
@@ -429,18 +444,23 @@ extension Struct: ImmutableMappable {
 		
 		prop27a = try map.value("prop27a")
 		prop27b = try map.value("prop27b")
+		prop27c = try map.value("prop27c")
 		
 		prop28a = try map.value("prop28a")
 		prop28b = try map.value("prop28b")
+		prop28c = try map.value("prop28c")
 		
 		prop29a = try map.value("prop29a")
 		prop29b = try map.value("prop29b")
+		prop29c = try map.value("prop29c")
 		
 		prop30a = try map.value("prop30a")
 		prop30b = try map.value("prop30b")
+		prop30c = try map.value("prop30c")
 		
 		prop31a = try map.value("prop31a")
 		prop31b = try map.value("prop31b")
+		prop31c = try map.value("prop31c")
 		
 		prop32 = try map.value("prop32", using: stringTransform)
 		prop33 = try? map.value("prop33", using: stringTransform)
@@ -500,18 +520,23 @@ extension Struct: ImmutableMappable {
 		
 		prop27a >>> map["prop27a"]
 		prop27b >>> map["prop27b"]
+		prop27c >>> map["prop27c"]
 		
 		prop28a >>> map["prop28a"]
 		prop28b >>> map["prop28b"]
+		prop28c >>> map["prop28c"]
 		
 		prop29a >>> map["prop29a"]
 		prop29b >>> map["prop29b"]
+		prop29c >>> map["prop29c"]
 		
 		prop30a >>> map["prop30a"]
 		prop30b >>> map["prop30b"]
+		prop30c >>> map["prop30c"]
 		
 		prop31a >>> map["prop31a"]
 		prop31b >>> map["prop31b"]
+		prop31c >>> map["prop31c"]
 
 		prop32 >>> (map["prop32"], stringTransform)
 		prop33 >>> (map["prop33"], stringTransform)


### PR DESCRIPTION
I have noticed that you can map `Raw Representable` type to a property without using `EnumTransform`, but when using array of raw representables you need to specify transform parameter otherwise mapping will fail.

Example:
```
let types: [TestType]    //TestType is Enum
let type: TestType

init(map: Map) throws {
    type = try map.value("type")
    types = try map.value("types")    // This will fail
} 
```

This is only valid for `ImmutableMappable`, on `Mappable` this already works without specifying tranform parameter. To be more consistent I have created this PR which solves this issue.