### PR TITLE
Append README Realm section

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ class Model: Object, Mappable {
 
 If you want to serialize associated RealmObjects, you can use [ObjectMapper+Realm](https://github.com/jakenberg/ObjectMapper-Realm). It is a simple Realm extension that serializes arbitrary JSON into Realm's List class.
 
+To serialize Swift String, Int, Double and Bool arrays you can use [ObjectMapperAdditions/Realm](https://github.com/APUtils/ObjectMapperAdditions#realm-features). It'll wrap Swift types into RealmValues that can be stored in Realm's List class.
+
 Note: Generating a JSON string of a Realm Object using ObjectMappers' `toJSON` function only works within a Realm write transaction. This is caused because ObjectMapper uses the `inout` flag in its mapping functions (`<-`) which are used both for serializing and deserializing. Realm detects the flag and forces the `toJSON` function to be called within a write block even though the objects are not being modified.
 
 # Projects Using ObjectMapper


### PR DESCRIPTION
Hey, not sure if it'll be useful but I added a link to ObjectMapper extension that adds a transforms to allow mapping from Swift String, Int, Double and Bool arrays into Realm Lists. 