### PR TITLE
Static ISO8601DateTransform Implementation

### DIFF
--- a/Sources/ISO8601DateTransform.swift
+++ b/Sources/ISO8601DateTransform.swift
@@ -28,14 +28,20 @@
 
 import Foundation
 
+public extension DateFormatter {
+	public convenience init(withFormat format : String, locale : String) {
+		self.init()
+		self.locale = Locale(identifier: locale)
+		dateFormat = format
+	}
+}
+
 open class ISO8601DateTransform: DateFormatterTransform {
+	
+	static let reusableISODateFormatter = DateFormatter(withFormat: "yyyy-MM-dd'T'HH:mm:ssZZZZZ", locale: "en_US_POSIX")
 
 	public init() {
-		let formatter = DateFormatter()
-		formatter.locale = Locale(identifier: "en_US_POSIX")
-		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-		
-		super.init(dateFormatter: formatter)
+		super.init(dateFormatter: ISO8601DateTransform.reusableISODateFormatter)
 	}
-	
 }
+


### PR DESCRIPTION
I am currently working on a project using the contentful.swift library, and was doing some performance testing for which I isolated this specific call to be very heavy on the CPU.

Due to the nature of contentful, and their API responses containing quite a few dates about the data, along with the content that I am retrieving, this turned into quite a bottleneck during the parsing process. Once I implemented this fix, the parsing time improved by about 30%, while the CPU load stayed under 100% during the parse process accordingly. Although only relative to my project, I believe that this fix could help out quite a few developers implementing your library.

I ran the tests, and it appears to pass :)


