### PR TITLE
Linux support

### DIFF
--- a/Sources/IntegerOperators.swift
+++ b/Sources/IntegerOperators.swift
@@ -90,30 +90,35 @@ public func <- <T: UnsignedInteger>(left: inout T!, right: Map) {
 
 /// Convert any value to `SignedInteger`.
 private func toSignedInteger<T: SignedInteger>(_ value: Any?) -> T? {
-	guard
-		let value = value,
-		case let number as NSNumber = value
-	else {
-		return nil
-	}
-
-	if T.self ==   Int.self, let x = Int(exactly: number.int64Value)?.toIntMax() {
-		return T.init(x)
-	}
-	if T.self ==  Int8.self, let x = Int8(exactly: number.int64Value)?.toIntMax() {
-		return T.init(x)
-	}
-	if T.self == Int16.self, let x = Int16(exactly: number.int64Value)?.toIntMax() {
-		return T.init(x)
-	}
-	if T.self == Int32.self, let x = Int32(exactly: number.int64Value)?.toIntMax() {
-		return T.init(x)
-	}
-	if T.self == Int64.self, let x = Int64(exactly: number.int64Value)?.toIntMax() {
-		return T.init(x)
-	}
-
-	return nil
+  guard let value = value else {
+    return nil
+  }
+  switch value{
+    case is Int:
+      let x = value as! Int
+      if T.self == Int.self { return T.init(x.toIntMax())}
+    case is NSNumber: 
+      let number = value as! NSNumber
+      if T.self == Int.self, let x = Int(exactly: number.int64Value)?.toIntMax() {
+        return T.init(x)
+      }
+      if T.self == Int8.self, let x = Int8(exactly: number.int64Value)?.toIntMax() {
+        return T.init(x)
+      }
+      if T.self == Int16.self, let x = Int16(exactly: number.int64Value)?.toIntMax() {
+        return T.init(x)
+      }
+      if T.self == Int32.self, let x = Int32(exactly: number.int64Value)?.toIntMax() {
+        return T.init(x)
+      }
+      if T.self == Int64.self, let x = Int64(exactly: number.int64Value)?.toIntMax() {
+        return T.init(x)
+      }
+    default:
+      print("NOTE: toSignedInteger: did not match \(type(of:value)) returning nil")
+      return nil
+  }
+  return nil
 }
 
 /// Convert any value to `UnsignedInteger`.

--- a/Sources/IntegerOperators.swift
+++ b/Sources/IntegerOperators.swift
@@ -94,9 +94,6 @@ private func toSignedInteger<T: SignedInteger>(_ value: Any?) -> T? {
     return nil
   }
   switch value{
-    case is Int:
-      let x = value as! Int
-      if T.self == Int.self { return T.init(x.toIntMax())}
     case is NSNumber: 
       let number = value as! NSNumber
       if T.self == Int.self, let x = Int(exactly: number.int64Value)?.toIntMax() {
@@ -114,6 +111,9 @@ private func toSignedInteger<T: SignedInteger>(_ value: Any?) -> T? {
       if T.self == Int64.self, let x = Int64(exactly: number.int64Value)?.toIntMax() {
         return T.init(x)
       }
+    case is Int:
+      let x = value as! Int
+      if T.self == Int.self { return T.init(x.toIntMax())}
     default:
       print("NOTE: toSignedInteger: did not match \(type(of:value)) returning nil")
       return nil

--- a/Sources/NSDecimalNumberTransform.swift
+++ b/Sources/NSDecimalNumberTransform.swift
@@ -39,6 +39,8 @@ open class NSDecimalNumberTransform: TransformType {
             return NSDecimalNumber(string: string)
         } else if let number = value as? NSNumber {
             return NSDecimalNumber(decimal: number.decimalValue)
+        } else if let number = value as? Int {
+            return NSDecimalNumber(decimal: Decimal(number))
         } else if let double = value as? Double {
             return NSDecimalNumber(floatLiteral: double)
         }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -13,4 +13,6 @@ XCTMain([
     testCase(IgnoreNilTests.allTests),
     testCase(ImmutableObjectTests.allTests),
     testCase(MapContextTests.allTests),
+    testCase(MappableExtensionsTests.allTests),
+    
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import ObjectMapperTests
 
 XCTMain([
+    testCase(BasicTypesTestsFromJSON.allTests),
+    testCase(BasicTypesTestsToJSON.allTests),
     testCase(NSDecimalNumberTransformTests.allTests),
     testCase(CustomTransformTests.allTests),
     testCase(ClassClusterTests.allTests)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -6,5 +6,8 @@ XCTMain([
     testCase(BasicTypesTestsToJSON.allTests),
     testCase(NSDecimalNumberTransformTests.allTests),
     testCase(CustomTransformTests.allTests),
-    testCase(ClassClusterTests.allTests)
+    testCase(ClassClusterTests.allTests),
+    testCase(DataTransformTests.allTests),
+    testCase(DictionaryTransformTests.allTests),
+    testCase(GenericObjectsTests.allTests),
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,7 +4,6 @@ import XCTest
 XCTMain([
     testCase(BasicTypesTestsFromJSON.allTests),
     testCase(BasicTypesTestsToJSON.allTests),
-    testCase(NSDecimalNumberTransformTests.allTests),
     testCase(CustomTransformTests.allTests),
     testCase(ClassClusterTests.allTests),
     testCase(DataTransformTests.allTests),
@@ -15,4 +14,12 @@ XCTMain([
     testCase(MapContextTests.allTests),
     testCase(MappableExtensionsTests.allTests),
     testCase(MappableTypesWithTransformsTests.allTests),
+    testCase(NestedArrayTests.allTests),
+    testCase(NestedKeysTests.allTests),
+    testCase(NSDecimalNumberTransformTests.allTests),
+    testCase(NullableKeysFromJSONTests.allTests),
+    testCase(ObjectMapperTests.allTests),
+    testCase(PerformanceTests.allTests),
+    testCase(ToObjectTests.allTests),
+    testCase(URLTransformTests.allTests)
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -14,5 +14,5 @@ XCTMain([
     testCase(ImmutableObjectTests.allTests),
     testCase(MapContextTests.allTests),
     testCase(MappableExtensionsTests.allTests),
-    
+    testCase(MappableTypesWithTransformsTests.allTests),
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -12,4 +12,5 @@ XCTMain([
     testCase(GenericObjectsTests.allTests),
     testCase(IgnoreNilTests.allTests),
     testCase(ImmutableObjectTests.allTests),
+    testCase(MapContextTests.allTests),
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -10,4 +10,6 @@ XCTMain([
     testCase(DataTransformTests.allTests),
     testCase(DictionaryTransformTests.allTests),
     testCase(GenericObjectsTests.allTests),
+    testCase(IgnoreNilTests.allTests),
+    testCase(ImmutableObjectTests.allTests),
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,5 +3,6 @@ import XCTest
 
 XCTMain([
     testCase(NSDecimalNumberTransformTests.allTests),
-    testCase(CustomTransformTests.allTests)
+    testCase(CustomTransformTests.allTests),
+    testCase(ClassClusterTests.allTests)
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import ObjectMapperTests
+
+XCTMain([
+    testCase(NSDecimalNumberTransformTests.allTests),
+    testCase(CustomTransformTests.allTests)
+])

--- a/Tests/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/Tests/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -615,3 +615,42 @@ class BasicTypesTestsFromJSON: XCTestCase {
 		XCTAssertTrue(testSet.dictStringFloat.count > 0)
 	}
 }
+
+#if os(Linux)
+extension BasicTypesTestsFromJSON {
+  static var allTests : [(String, (BasicTypesTestsFromJSON) -> () throws -> Void)] {
+    return [
+      ("testMappingBoolFromJSON", testMappingBoolFromJSON),
+      ("testMappingIntegerFromJSON", testMappingIntegerFromJSON),
+      ("testMappingIntegerWithOverflowFromJSON", testMappingIntegerWithOverflowFromJSON),
+      ("testMappingDoubleFromJSON", testMappingDoubleFromJSON),
+      ("testMappingFloatFromJSON", testMappingFloatFromJSON),
+      ("testMappingStringFromJSON", testMappingStringFromJSON),
+      ("testMappingAnyObjectFromJSON", testMappingAnyObjectFromJSON),
+      ("testMappingStringFromNSStringJSON", testMappingStringFromNSStringJSON),
+      ("testMappingBoolArrayFromJSON", testMappingBoolArrayFromJSON),
+      ("testMappingIntArrayFromJSON", testMappingIntArrayFromJSON),
+      ("testMappingDoubleArrayFromJSON", testMappingDoubleArrayFromJSON),
+      // ("testMappingFloatArrayFromJSON", testMappingFloatArrayFromJSON),
+      ("testMappingStringArrayFromJSON", testMappingStringArrayFromJSON),
+      ("testMappingAnyObjectArrayFromJSON", testMappingAnyObjectArrayFromJSON),
+      // ("testMappingBoolDictionaryFromJSON", testMappingBoolDictionaryFromJSON),
+      ("testMappingIntDictionaryFromJSON", testMappingIntDictionaryFromJSON),
+      ("testMappingDoubleDictionaryFromJSON", testMappingDoubleDictionaryFromJSON),
+      // ("testMappingFloatDictionaryFromJSON", testMappingFloatDictionaryFromJSON),
+      ("testMappingStringDictionaryFromJSON", testMappingStringDictionaryFromJSON),
+      ("testMappingAnyObjectDictionaryFromJSON", testMappingAnyObjectDictionaryFromJSON),
+      ("testMappingIntEnumFromJSON", testMappingIntEnumFromJSON),
+      ("testMappingIntEnumFromJSONShouldNotCrashWithNonDefinedvalue", testMappingIntEnumFromJSONShouldNotCrashWithNonDefinedvalue),
+      ("testMappingDoubleEnumFromJSON", testMappingDoubleEnumFromJSON),
+      ("testMappingFloatEnumFromJSON", testMappingFloatEnumFromJSON),
+      ("testMappingStringEnumFromJSON", testMappingStringEnumFromJSON),
+      ("testMappingEnumIntArrayFromJSON", testMappingEnumIntArrayFromJSON),
+      ("testMappingEnumIntArrayFromJSONShouldNotCrashWithNonDefinedvalue", testMappingEnumIntArrayFromJSONShouldNotCrashWithNonDefinedvalue),
+      ("testMappingEnumIntDictionaryFromJSON", testMappingEnumIntDictionaryFromJSON),
+      ("testMappingEnumIntDictionaryFromJSONShouldNotCrashWithNonDefinedvalue", testMappingEnumIntDictionaryFromJSONShouldNotCrashWithNonDefinedvalue),
+      ("testObjectModelOptionalDictionnaryOfPrimitives", testObjectModelOptionalDictionnaryOfPrimitives)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/BasicTypesTestsFromJSON.swift
+++ b/Tests/ObjectMapperTests/BasicTypesTestsFromJSON.swift
@@ -321,9 +321,10 @@ class BasicTypesTestsFromJSON: XCTestCase {
 
 	func testMappingStringFromNSStringJSON(){
 		let value: String = "STRINGNGNGG"
-		let JSONNSString : NSString = "{\"string\" : \"\(value)\", \"stringOpt\" : \"\(value)\", \"stringImp\" : \"\(value)\"}" as NSString
+
+		let JSONNSString = NSString.init(string: "{\"string\" : \"\(value)\", \"stringOpt\" : \"\(value)\", \"stringImp\" : \"\(value)\"}")
 		
-		let mappedObject = mapper.map(JSONString: JSONNSString as String)
+		let mappedObject = mapper.map(JSONString: String(describing: JSONNSString))
 
 		XCTAssertNotNil(mappedObject)
 		XCTAssertEqual(mappedObject?.string, value)

--- a/Tests/ObjectMapperTests/BasicTypesTestsToJSON.swift
+++ b/Tests/ObjectMapperTests/BasicTypesTestsToJSON.swift
@@ -574,3 +574,40 @@ class BasicTypesTestsToJSON: XCTestCase {
 		XCTAssertEqual((json["dictStringString"] as? [String:String])?["string"], "string")
 	}
 }
+
+#if os(Linux)
+extension BasicTypesTestsToJSON {
+  static var allTests : [(String, (BasicTypesTestsToJSON) -> () throws -> Void)] {
+    return [
+      ("testShouldIncludeNilValues", testShouldIncludeNilValues),
+      ("testMappingBoolToJSON", testMappingBoolToJSON),
+      ("testMappingIntegerToJSON", testMappingIntegerToJSON),
+      ("testMappingDoubleToJSON", testMappingDoubleToJSON),
+      ("testMappingFloatToJSON", testMappingFloatToJSON),
+      ("testMappingStringToJSON", testMappingStringToJSON),
+      ("testMappingAnyObjectToJSON", testMappingAnyObjectToJSON),
+      ("testMappingEmptyArrayToJSON", testMappingEmptyArrayToJSON),
+      ("testMappingBoolArrayToJSON", testMappingBoolArrayToJSON),
+      ("testMappingIntArrayToJSON", testMappingIntArrayToJSON),
+      // ("testMappingDoubleArrayToJSON", testMappingDoubleArrayToJSON),
+      // ("testMappingFloatArrayToJSON", testMappingFloatArrayToJSON),
+      ("testMappingStringArrayToJSON", testMappingStringArrayToJSON),
+      ("testMappingAnyObjectArrayToJSON", testMappingAnyObjectArrayToJSON),
+      ("testMappingEmptyDictionaryToJSON", testMappingEmptyDictionaryToJSON),
+      ("testMappingBoolDictionaryToJSON", testMappingBoolDictionaryToJSON),
+      ("testMappingIntDictionaryToJSON", testMappingIntDictionaryToJSON),
+      // ("testMappingDoubleDictionaryToJSON", testMappingDoubleDictionaryToJSON),
+      // ("testMappingFloatDictionaryToJSON", testMappingFloatDictionaryToJSON),
+      ("testMappingStringDictionaryToJSON", testMappingStringDictionaryToJSON),
+      ("testMappingAnyObjectDictionaryToJSON", testMappingAnyObjectDictionaryToJSON),
+      ("testMappingIntEnumToJSON", testMappingIntEnumToJSON),
+      ("testMappingDoubleEnumToJSON", testMappingDoubleEnumToJSON),
+      ("testMappingFloatEnumToJSON", testMappingFloatEnumToJSON),
+      ("testMappingStringEnumToJSON", testMappingStringEnumToJSON),
+      ("testMappingEnumIntArrayToJSON", testMappingEnumIntArrayToJSON),
+      ("testMappingEnumIntDictionaryToJSON", testMappingEnumIntDictionaryToJSON),
+      ("testObjectToModelDictionnaryOfPrimitives", testObjectToModelDictionnaryOfPrimitives)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/ClassClusterTests.swift
+++ b/Tests/ObjectMapperTests/ClassClusterTests.swift
@@ -42,7 +42,7 @@ class ClassClusterTests: XCTestCase {
         super.tearDown()
     }
 	
-    func testClassClusters() {
+  func testClassClusters() {
 		let carName = "Honda"
 		let JSON = ["name": carName, "type": "car"]
 		
@@ -51,7 +51,7 @@ class ClassClusterTests: XCTestCase {
 			XCTAssertNotNil(vehicle as? Car)
 			XCTAssertEqual((vehicle as? Car)?.name, carName)
 		}
-    }
+  }
 	
 	func testClassClustersFromJSONString() {
 		let carName = "Honda"
@@ -126,3 +126,15 @@ class Bus: Vehicle {
 		super.mapping(map: map)
 	}
 }
+
+#if os(Linux)
+extension ClassClusterTests {
+  static var allTests : [(String, (ClassClusterTests) -> () throws -> Void)] {
+    return [
+      ("testClassClusters", testClassClusters),
+      ("testClassClustersFromJSONString", testClassClustersFromJSONString),
+      ("testClassClusterArray", testClassClusterArray)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/CustomTransformTests.swift
+++ b/Tests/ObjectMapperTests/CustomTransformTests.swift
@@ -32,6 +32,7 @@ import ObjectMapper
 
 #if os(iOS) || os(tvOS) || os(watchOS)
 	typealias TestHexColor = UIColor
+#elseif os(Linux)
 #else
 	typealias TestHexColor = NSColor
 #endif
@@ -116,7 +117,7 @@ class CustomTransformTests: XCTestCase {
 	
 	func testInt64MaxValue() {
 		let transforms = Transforms()
-		transforms.int64Value = INT64_MAX
+		transforms.int64Value = Int64.max
 		
 		let JSON = mapper.toJSON(transforms)
 

--- a/Tests/ObjectMapperTests/CustomTransformTests.swift
+++ b/Tests/ObjectMapperTests/CustomTransformTests.swift
@@ -151,34 +151,37 @@ class CustomTransformTests: XCTestCase {
 		XCTAssertEqual(transforms?.secondImageType, imageType.Thumbnail)
 	}
 	
-	func testHexColorTransform() {
-		let JSON: [String: Any] = [
-			"colorRed": "#FF0000",
-			"colorGreenLowercase": "#00FF00",
-			"colorBlueWithoutHash": "0000FF",
-			"color3lenght": "F00",
-			"color4lenght": "F00f",
-			"color8lenght": "ff0000ff"
-		]
-		
-		let transform = mapper.map(JSON: JSON)
-		
-		XCTAssertEqual(transform?.colorRed, TestHexColor.red)
-		XCTAssertEqual(transform?.colorGreenLowercase, TestHexColor.green)
-		XCTAssertEqual(transform?.colorBlueWithoutHash, TestHexColor.blue)
-		XCTAssertEqual(transform?.color3lenght, TestHexColor.red)
-		XCTAssertEqual(transform?.color4lenght, TestHexColor.red)
-		XCTAssertEqual(transform?.color8lenght, TestHexColor.red)
-		
-		let JSONOutput = mapper.toJSON(transform!)
-		
-		XCTAssertEqual(JSONOutput["colorRed"] as? String, "FF0000")
-		XCTAssertEqual(JSONOutput["colorGreenLowercase"] as? String, "00FF00")
-		XCTAssertEqual(JSONOutput["colorBlueWithoutHash"] as? String, "#0000FF") // prefixToJSON = true
-		XCTAssertEqual(JSONOutput["color3lenght"] as? String, "FF0000")
-		XCTAssertEqual(JSONOutput["color4lenght"] as? String, "FF0000")
-		XCTAssertEqual(JSONOutput["color8lenght"] as? String, "FF0000FF") // alphaToJSON = true
-	}
+	#if os(Linux)
+	#else
+		func testHexColorTransform() {
+			let JSON: [String: Any] = [
+				"colorRed": "#FF0000",
+				"colorGreenLowercase": "#00FF00",
+				"colorBlueWithoutHash": "0000FF",
+				"color3lenght": "F00",
+				"color4lenght": "F00f",
+				"color8lenght": "ff0000ff"
+			]
+			
+			let transform = mapper.map(JSON: JSON)
+			
+			XCTAssertEqual(transform?.colorRed, TestHexColor.red)
+			XCTAssertEqual(transform?.colorGreenLowercase, TestHexColor.green)
+			XCTAssertEqual(transform?.colorBlueWithoutHash, TestHexColor.blue)
+			XCTAssertEqual(transform?.color3lenght, TestHexColor.red)
+			XCTAssertEqual(transform?.color4lenght, TestHexColor.red)
+			XCTAssertEqual(transform?.color8lenght, TestHexColor.red)
+			
+			let JSONOutput = mapper.toJSON(transform!)
+			
+			XCTAssertEqual(JSONOutput["colorRed"] as? String, "FF0000")
+			XCTAssertEqual(JSONOutput["colorGreenLowercase"] as? String, "00FF00")
+			XCTAssertEqual(JSONOutput["colorBlueWithoutHash"] as? String, "#0000FF") // prefixToJSON = true
+			XCTAssertEqual(JSONOutput["color3lenght"] as? String, "FF0000")
+			XCTAssertEqual(JSONOutput["color4lenght"] as? String, "FF0000")
+			XCTAssertEqual(JSONOutput["color8lenght"] as? String, "FF0000FF") // alphaToJSON = true
+		}
+	#endif
 }
 
 class Transforms: Mappable {
@@ -208,12 +211,15 @@ class Transforms: Mappable {
 	var firstImageType: ImageType?
 	var secondImageType: ImageType?
 	
-	var colorRed: TestHexColor?
-	var colorGreenLowercase: TestHexColor?
-	var colorBlueWithoutHash: TestHexColor?
-	var color3lenght: TestHexColor?
-	var color4lenght: TestHexColor?
-	var color8lenght: TestHexColor?
+	#if os(Linux)
+	#else
+		var colorRed: TestHexColor?
+		var colorGreenLowercase: TestHexColor?
+		var colorBlueWithoutHash: TestHexColor?
+		var color3lenght: TestHexColor?
+		var color4lenght: TestHexColor?
+		var color8lenght: TestHexColor?
+	#endif
 
 	init(){
 		
@@ -243,12 +249,32 @@ class Transforms: Mappable {
 		firstImageType		<- (map["firstImageType"], EnumTransform<ImageType>())
 		secondImageType		<- (map["secondImageType"], EnumTransform<ImageType>())
 		
-		colorRed			<- (map["colorRed"], HexColorTransform())
-		colorGreenLowercase <- (map["colorGreenLowercase"], HexColorTransform())
-		colorBlueWithoutHash <- (map["colorBlueWithoutHash"], HexColorTransform(prefixToJSON: true))
-		color3lenght			<- (map["color3lenght"], HexColorTransform())
-		color4lenght			<- (map["color4lenght"], HexColorTransform())
-		color8lenght			<- (map["color8lenght"], HexColorTransform(alphaToJSON: true))
+		#if os(Linux)
+		#else
+			colorRed			<- (map["colorRed"], HexColorTransform())
+			colorGreenLowercase <- (map["colorGreenLowercase"], HexColorTransform())
+			colorBlueWithoutHash <- (map["colorBlueWithoutHash"], HexColorTransform(prefixToJSON: true))
+			color3lenght			<- (map["color3lenght"], HexColorTransform())
+			color4lenght			<- (map["color4lenght"], HexColorTransform())
+			color8lenght			<- (map["color8lenght"], HexColorTransform(alphaToJSON: true))
+		#endif
 	}
 }
 
+
+#if os(Linux)
+extension CustomTransformTests {
+  static var allTests : [(String, (CustomTransformTests) -> () throws -> Void)] {
+    return [
+      ("testDateTransform", testDateTransform),
+      ("testISO8601DateTransform", testISO8601DateTransform),
+      ("testISO8601DateTransformWithInvalidInput", testISO8601DateTransformWithInvalidInput),
+      ("testCustomFormatDateTransform", testCustomFormatDateTransform),
+      ("testIntToStringTransformOf", testIntToStringTransformOf),
+      ("testInt64MaxValue", testInt64MaxValue),
+      ("testURLTranform", testURLTranform),
+      ("testEnumTransform", testEnumTransform)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/DataTransformTests.swift
+++ b/Tests/ObjectMapperTests/DataTransformTests.swift
@@ -69,3 +69,13 @@ class DataType: Mappable {
 		data <- (map["data"], DataTransform())
 	}
 }
+
+#if os(Linux)
+extension DataTransformTests {
+  static var allTests : [(String, (DataTransformTests) -> () throws -> Void)] {
+    return [
+      ("testDataTransform", testDataTransform)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/DictionaryTransformTests.swift
+++ b/Tests/ObjectMapperTests/DictionaryTransformTests.swift
@@ -108,3 +108,13 @@ extension DictionaryTransformTestsObject {
 	}
 }
 
+#if os(Linux)
+extension DictionaryTransformTests {
+  static var allTests : [(String, (DictionaryTransformTests) -> () throws -> Void)] {
+    return [
+      ("testDictionaryTransform", testDictionaryTransform)
+    ]
+  }
+}
+#endif
+

--- a/Tests/ObjectMapperTests/GenericObjectsTests.swift
+++ b/Tests/ObjectMapperTests/GenericObjectsTests.swift
@@ -202,3 +202,17 @@ class Response<T: Mappable>: Mappable {
 		result <- map["result"]
 	}
 }
+
+#if os(Linux)
+extension GenericObjectsTests {
+  static var allTests : [(String, (GenericObjectsTests) -> () throws -> Void)] {
+    return [
+      ("testSubclass", testSubclass),
+      ("testGenericSubclass", testGenericSubclass),
+      ("testSubclassWithGenericArrayInSuperclass", testSubclassWithGenericArrayInSuperclass),
+      ("testMappingAGenericObject", testMappingAGenericObject),
+      ("testMappingAGenericObjectViaMappableExtension", testMappingAGenericObjectViaMappableExtension)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/IgnoreNilTests.swift
+++ b/Tests/ObjectMapperTests/IgnoreNilTests.swift
@@ -77,3 +77,14 @@ class IgnoreNilTests: XCTestCase {
 		}
 	}
 }
+
+#if os(Linux)
+extension IgnoreNilTests {
+  static var allTests : [(String, (IgnoreNilTests) -> () throws -> Void)] {
+    return [
+      ("testIgnoreNullField", testIgnoreNullField),
+      ("testIgnoreNilField", testIgnoreNilField)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/ImmutableTests.swift
+++ b/Tests/ObjectMapperTests/ImmutableTests.swift
@@ -605,3 +605,26 @@ private func assertImmutableObjectsEqual(_ lhs: Struct, _ rhs: Struct) {
 	XCTAssertEqual("\(lhs.prop36 as Optional)", "\(rhs.prop36 as Optional)")
 	XCTAssertEqual("\(lhs.prop37)", "\(rhs.prop37)")
 }
+
+
+
+#if os(Linux)
+extension ImmutableObjectTests {
+  static var allTests : [(String, (ImmutableObjectTests) -> () throws -> Void)] {
+    return [
+      // ("testImmutableMappable", testImmutableMappable),
+      ("testMappingFromArray", testMappingFromArray),
+      ("testMappingFromDictionary", testMappingFromDictionary),
+      ("testMappingFromDictionary_empty", testMappingFromDictionary_empty),
+      ("testMappingFromDictionary_throws", testMappingFromDictionary_throws),
+      ("testMappingFromDictionaryOfArrays", testMappingFromDictionaryOfArrays),
+      ("testMappingFromDictionaryOfArrays_empty", testMappingFromDictionaryOfArrays_empty),
+      ("testMappingFromDictionaryOfArrays_throws", testMappingFromDictionaryOfArrays_throws),
+      ("testMappingArrayOfArrays", testMappingArrayOfArrays),
+      ("testMappingArrayOfArrays_empty", testMappingArrayOfArrays_empty),
+      ("testMappingArrayOfArrays_throws", testMappingArrayOfArrays_throws),
+      ("testAsPropertyOfMappable", testAsPropertyOfMappable)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/MapContextTests.swift
+++ b/Tests/ObjectMapperTests/MapContextTests.swift
@@ -334,3 +334,30 @@ class MapContextTests: XCTestCase {
 		}
 	}
 }
+
+#if os(Linux)
+extension MapContextTests {
+  static var allTests : [(String, (MapContextTests) -> () throws -> Void)] {
+    return [
+      ("testMappingWithContext",testMappingWithContext),
+			("testMappingWithContextViaMappableExtension",testMappingWithContextViaMappableExtension),
+			("testMappingWithoutContext",testMappingWithoutContext),
+			("testNestedMappingWithContext",testNestedMappingWithContext),
+			("testNestedMappingWithContextViaMappableExtension",testNestedMappingWithContextViaMappableExtension),
+			("testNestedMappingWithoutContext",testNestedMappingWithoutContext),
+			("testArrayMappingWithContext",testArrayMappingWithContext),
+			("testArrayMappingWithContextViaMappableExtension",testArrayMappingWithContextViaMappableExtension),
+			("testArrayMappingWithoutContext",testArrayMappingWithoutContext),
+			("testImmatableMappingWithContext",testImmatableMappingWithContext),
+			("testImmatableMappingWithContextViaMappableExtension",testImmatableMappingWithContextViaMappableExtension),
+			("testImmatableMappingWithoutContext",testImmatableMappingWithoutContext),
+			("testNestedImmutableMappingWithContext",testNestedImmutableMappingWithContext),
+			("testNestedImmutableMappingWithContextViaMappableExtension",testNestedImmutableMappingWithContextViaMappableExtension),
+			("testNestedImmutableMappingWithoutContext",testNestedImmutableMappingWithoutContext),
+			("testArrayImmutableMappingWithContext",testArrayImmutableMappingWithContext),
+			("testArrayImmutableMappingWithContextViaMappableExtension",testArrayImmutableMappingWithContextViaMappableExtension),
+			("testArrayImmutableMappingWithoutContext",testArrayImmutableMappingWithoutContext)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/MappableExtensionsTests.swift
+++ b/Tests/ObjectMapperTests/MappableExtensionsTests.swift
@@ -103,3 +103,19 @@ class MappableExtensionsTests: XCTestCase {
 		XCTAssertEqual(mapped, [testMappable])
 	}
 }
+
+#if os(Linux)
+extension MappableExtensionsTests {
+  static var allTests : [(String, (MappableExtensionsTests) -> () throws -> Void)] {
+    return [
+     	("testInitFromString",testInitFromString),
+			("testToJSONAndBack",testToJSONAndBack),
+			("testArrayFromString",testArrayFromString),
+			("testArrayToJSONAndBack",testArrayToJSONAndBack),
+			("testSetInitFailsWithEmptyString",testSetInitFailsWithEmptyString),
+			("testSetFromString",testSetFromString),
+			("testSetToJSONAndBack",testSetToJSONAndBack)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/MappableExtensionsTests.swift
+++ b/Tests/ObjectMapperTests/MappableExtensionsTests.swift
@@ -49,7 +49,7 @@ struct TestMappable: Mappable, Equatable, Hashable {
 		if let value = value {
 			return value.hashValue
 		}
-		return NSIntegerMax
+		return Int.max
 	}
 }
 

--- a/Tests/ObjectMapperTests/MappableTypesWithTransformsTests.swift
+++ b/Tests/ObjectMapperTests/MappableTypesWithTransformsTests.swift
@@ -341,3 +341,30 @@ class RelationshipTransform<ObjectType>: TransformType where ObjectType: Mappabl
 		return nil
 	}
 }
+
+#if os(Linux)
+extension MappableTypesWithTransformsTests {
+  static var allTests : [(String, (MappableTypesWithTransformsTests) -> () throws -> Void)] {
+    return [
+      ("testParsingSingleInstanceWithTransform",testParsingSingleInstanceWithTransform),
+      ("testParsingArrayOfObjectsWithTransform",testParsingArrayOfObjectsWithTransform),
+      ("testParsing2DimensionalArrayOfObjectsWithTransform",testParsing2DimensionalArrayOfObjectsWithTransform),
+      ("testParsingDictionaryOfObjectsWithTransform",testParsingDictionaryOfObjectsWithTransform),
+      ("testParsingDictionaryOfArrayOfObjectsWithTransform",testParsingDictionaryOfArrayOfObjectsWithTransform),
+      ("testParsingSetOfObjectsWithTransform",testParsingSetOfObjectsWithTransform),
+      ("testParsingOptionalSingleInstanceWithTransform",testParsingOptionalSingleInstanceWithTransform),
+      ("testParsingOptionalArrayOfObjectsWithTransform",testParsingOptionalArrayOfObjectsWithTransform),
+      ("testParsingOptional2DimensionalArrayOfObjectsWithTransform",testParsingOptional2DimensionalArrayOfObjectsWithTransform),
+      ("testParsingOptionalDictionaryOfObjectsWithTransform",testParsingOptionalDictionaryOfObjectsWithTransform),
+      ("testParsingOptionalDictionaryOfArrayOfObjectsWithTransform",testParsingOptionalDictionaryOfArrayOfObjectsWithTransform),
+      ("testParsingOptionalSetOfObjectsWithTransform",testParsingOptionalSetOfObjectsWithTransform),
+      ("testParsingImplicitlyUnwrappedSingleInstanceWithTransform",testParsingImplicitlyUnwrappedSingleInstanceWithTransform),
+      ("testParsingImplicitlyUnwrappedArrayOfObjectsWithTransform",testParsingImplicitlyUnwrappedArrayOfObjectsWithTransform),
+      ("testParsingImplicitlyUnwrapped2DimensionalArrayOfObjectsWithTransform",testParsingImplicitlyUnwrapped2DimensionalArrayOfObjectsWithTransform),
+      ("testParsingImplicitlyUnwrappedDictionaryOfObjectsWithTransform",testParsingImplicitlyUnwrappedDictionaryOfObjectsWithTransform),
+      ("testParsingImplicitlyUnwrappedDictionaryOfArrayOfObjectsWithTransform",testParsingImplicitlyUnwrappedDictionaryOfArrayOfObjectsWithTransform),
+      ("testParsingImplicitlyUnwrappedSetOfObjectsWithTransform",testParsingImplicitlyUnwrappedSetOfObjectsWithTransform)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/NSDecimalNumberTransformTests.swift
+++ b/Tests/ObjectMapperTests/NSDecimalNumberTransformTests.swift
@@ -46,8 +46,8 @@ class NSDecimalNumberTransformTests: XCTestCase {
         let mappedObject = mapper.map(JSONString: JSONString)
 
         XCTAssertNotNil(mappedObject)
-        XCTAssertEqual(mappedObject?.int, NSDecimalNumber(value: int))
-        XCTAssertEqual(mappedObject?.double, NSDecimalNumber(value: double))
+        XCTAssertEqual(mappedObject?.int, NSDecimalNumber(decimal: Decimal(int)))
+        XCTAssertEqual(mappedObject?.double, NSDecimalNumber(decimal: Decimal(double)))
         XCTAssertEqual(mappedObject?.decimal, NSDecimalNumber(decimal: decimal))
         XCTAssertEqual(mappedObject?.intString, NSDecimalNumber(string: intString))
         XCTAssertEqual(mappedObject?.doubleString, NSDecimalNumber(string: doubleString))

--- a/Tests/ObjectMapperTests/NSDecimalNumberTransformTests.swift
+++ b/Tests/ObjectMapperTests/NSDecimalNumberTransformTests.swift
@@ -84,3 +84,13 @@ class NSDecimalNumberType: Mappable {
         decimalString <- (map["decimalString"], NSDecimalNumberTransform())
     }
 }
+
+#if os(Linux)
+extension NSDecimalNumberTransformTests {
+  static var allTests : [(String, (NSDecimalNumberTransformTests) -> () throws -> Void)] {
+    return [
+      ("testNSDecimalNumberTransform", testNSDecimalNumberTransform)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/NestedArrayTests.swift
+++ b/Tests/ObjectMapperTests/NestedArrayTests.swift
@@ -103,3 +103,14 @@ class NestedObject: Mappable {
 		value	<- map["value"]
 	}
 }
+
+#if os(Linux)
+extension NestedArrayTests {
+  static var allTests : [(String, (NestedArrayTests) -> () throws -> Void)] {
+    return [
+     	("testNestedArray",testNestedArray),
+			("testNestedObjectArray",testNestedObjectArray)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/NestedKeysTests.swift
+++ b/Tests/ObjectMapperTests/NestedKeysTests.swift
@@ -399,3 +399,14 @@ enum StringEnum: String {
 	case A = "String A"
 	case B = "String B"
 }
+
+#if os(Linux)
+extension NestedKeysTests {
+  static var allTests : [(String, (NestedKeysTests) -> () throws -> Void)] {
+    return [
+     	("testNestedKeys",testNestedKeys),
+			("testNestedKeysWithDelimiter",testNestedKeysWithDelimiter)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/NestedKeysTests.swift
+++ b/Tests/ObjectMapperTests/NestedKeysTests.swift
@@ -46,7 +46,7 @@ class NestedKeysTests: XCTestCase {
 		let JSON: [String: Any] = [
 			"non.nested.key": "string",
 			"nested": [
-				"int64": NSNumber(value: INT64_MAX),
+				"int64": NSNumber(value: Int64.max),
 				"bool": true,
 				"int": 255,
 				"double": 100.0 as Double,
@@ -54,14 +54,14 @@ class NestedKeysTests: XCTestCase {
 				"string": "String!",
 
 				"nested": [
-					"int64Array": [NSNumber(value: INT64_MAX), NSNumber(value: INT64_MAX - 1), NSNumber(value: INT64_MAX - 10)],
+					"int64Array": [NSNumber(value: Int64.max), NSNumber(value: Int64.max - 1), NSNumber(value: Int64.max - 10)],
 					"boolArray": [false, true, false],
 					"intArray": [1, 2, 3],
 					"doubleArray": [1.0, 2.0, 3.0],
 					"floatArray": [1.0 as Float, 2.0 as Float, 3.0 as Float],
 					"stringArray": ["123", "ABC"],
 
-					"int64Dict": ["1": NSNumber(value: INT64_MAX)],
+					"int64Dict": ["1": NSNumber(value: Int64.max)],
 					"boolDict": ["2": true],
 					"intDict": ["3": 999],
 					"doubleDict": ["4": 999.999],
@@ -130,7 +130,7 @@ class NestedKeysTests: XCTestCase {
 		let JSON: [String: Any] = [
 			"non.nested->key": "string",
 			"com.hearst.ObjectMapper.nested": [
-				"com.hearst.ObjectMapper.int64": NSNumber(value: INT64_MAX),
+				"com.hearst.ObjectMapper.int64": NSNumber(value: Int64.max),
 				"com.hearst.ObjectMapper.bool": true,
 				"com.hearst.ObjectMapper.int": 255,
 				"com.hearst.ObjectMapper.double": 100.0 as Double,
@@ -138,14 +138,14 @@ class NestedKeysTests: XCTestCase {
 				"com.hearst.ObjectMapper.string": "String!",
 
 				"com.hearst.ObjectMapper.nested": [
-					"int64Array": [NSNumber(value: INT64_MAX), NSNumber(value: INT64_MAX - 1), NSNumber(value: INT64_MAX - 10)],
+					"int64Array": [NSNumber(value: Int64.max), NSNumber(value: Int64.max - 1), NSNumber(value: Int64.max - 10)],
 					"boolArray": [false, true, false],
 					"intArray": [1, 2, 3],
 					"doubleArray": [1.0, 2.0, 3.0],
 					"floatArray": [1.0 as Float, 2.0 as Float, 3.0 as Float],
 					"stringArray": ["123", "ABC"],
 
-					"int64Dict": ["1": NSNumber(value: INT64_MAX)],
+					"int64Dict": ["1": NSNumber(value: Int64.max)],
 					"boolDict": ["2": true],
 					"intDict": ["3": 999],
 					"doubleDict": ["4": 999.999],
@@ -174,14 +174,14 @@ class NestedKeysTests: XCTestCase {
 
 		XCTAssertEqual(value.nonNestedString, "string")
 		
-		XCTAssertEqual(value.int64, NSNumber(value: INT64_MAX))
+		XCTAssertEqual(value.int64, NSNumber(value: Int64.max))
 		XCTAssertEqual(value.bool, true)
 		XCTAssertEqual(value.int, 255)
 		XCTAssertEqual(value.double, 100.0 as Double)
 		XCTAssertEqual(value.float, 50.0 as Float)
 		XCTAssertEqual(value.string, "String!")
 
-		let int64Array = [NSNumber(value: INT64_MAX), NSNumber(value: INT64_MAX - 1), NSNumber(value: INT64_MAX - 10)]
+		let int64Array = [NSNumber(value: Int64.max), NSNumber(value: Int64.max - 1), NSNumber(value: Int64.max - 10)]
 		XCTAssertEqual(value.int64Array, int64Array)
 		XCTAssertEqual(value.boolArray, [false, true, false])
 		XCTAssertEqual(value.intArray, [1, 2, 3])
@@ -189,7 +189,7 @@ class NestedKeysTests: XCTestCase {
 		XCTAssertEqual(value.floatArray, [1.0 as Float, 2.0 as Float, 3.0 as Float])
 		XCTAssertEqual(value.stringArray, ["123", "ABC"])
 
-		XCTAssertEqual(value.int64Dict, ["1": NSNumber(value: INT64_MAX)])
+		XCTAssertEqual(value.int64Dict, ["1": NSNumber(value: Int64.max)])
 		XCTAssertEqual(value.boolDict, ["2": true])
 		XCTAssertEqual(value.intDict, ["3": 999])
 		XCTAssertEqual(value.doubleDict, ["4": 999.999])

--- a/Tests/ObjectMapperTests/NullableKeysFromJSONTests.swift
+++ b/Tests/ObjectMapperTests/NullableKeysFromJSONTests.swift
@@ -38,12 +38,12 @@ class NullableKeysFromJSONTests: XCTestCase {
 
 	let mapper = Mapper<Player>()
 
-    override func setUp() {
-        super.setUp()
+  override func setUp() {
+      super.setUp()
 		// Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    func testMapperNullifiesValues() {
+  }
+  
+  func testMapperNullifiesValues() {
 		guard let player = mapper.map(JSONString: fullJSONString) else {
 			XCTFail("Mapping failed")
 			return
@@ -59,7 +59,7 @@ class NullableKeysFromJSONTests: XCTestCase {
 		XCTAssertNil(player.lastName)
 		XCTAssertNil(player.age)
 		XCTAssertNil(player.address?.city)
-    }
+  }
 
 	func testMapperAbsentValues() {
 		guard let player = mapper.map(JSONString: fullJSONString) else {
@@ -116,3 +116,15 @@ class Address: Mappable {
 		city <- map["city"]
 	}
 }
+
+#if os(Linux)
+extension NullableKeysFromJSONTests {
+  static var allTests : [(String, (NullableKeysFromJSONTests) -> () throws -> Void)] {
+    return [
+     	("testMapperNullifiesValues",testMapperNullifiesValues),
+			("testMapperAbsentValues",testMapperAbsentValues)
+    ]
+  }
+}
+#endif
+

--- a/Tests/ObjectMapperTests/ObjectMapperTests.swift
+++ b/Tests/ObjectMapperTests/ObjectMapperTests.swift
@@ -656,3 +656,33 @@ struct CachedItem: Mappable {
 		name <- map["name"]
 	}
 }
+
+#if os(Linux)
+extension ObjectMapperTests {
+  static var allTests : [(String, (ObjectMapperTests) -> () throws -> Void)] {
+    return [
+      ("testBasicParsing",testBasicParsing),
+      ("testOptionalStringParsing",testOptionalStringParsing),
+      ("testInstanceParsing",testInstanceParsing),
+      ("testDictionaryParsing",testDictionaryParsing),
+      ("testNullObject",testNullObject),
+      ("testToJSONAndBack",testToJSONAndBack),
+      ("testToJSONArrayAndBack",testToJSONArrayAndBack),
+      ("testUnknownPropertiesIgnored",testUnknownPropertiesIgnored),
+      ("testInvalidJsonResultsInNilObject",testInvalidJsonResultsInNilObject),
+      ("testMapArrayJSON",testMapArrayJSON),
+      ("testMapArrayJSONWithNoArray",testMapArrayJSONWithNoArray),
+      ("testMapArrayJSONWithEmptyArray",testMapArrayJSONWithEmptyArray),
+      ("testArrayOfCustomObjects",testArrayOfCustomObjects),
+      ("testDictionaryOfArrayOfCustomObjects",testDictionaryOfArrayOfCustomObjects),
+      ("testArrayOfEnumObjects",testArrayOfEnumObjects),
+      ("testDictionaryOfCustomObjects",testDictionaryOfCustomObjects),
+      ("testDictionryOfEnumObjects",testDictionryOfEnumObjects),
+      ("testDoubleParsing",testDoubleParsing),
+      ("testToJSONArray",testToJSONArray),
+      ("testArrayOfArrayOfMappable",testArrayOfArrayOfMappable),
+      ("testShouldPreventOverwritingMappableProperty",testShouldPreventOverwritingMappableProperty)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/PerformanceTests.swift
+++ b/Tests/ObjectMapperTests/PerformanceTests.swift
@@ -171,4 +171,14 @@ class PerformanceImmutableMappableObject: ImmutableMappable {
 	}
 }
 
-
+#if os(Linux)
+extension PerformanceTests {
+  static var allTests : [(String, (PerformanceTests) -> () throws -> Void)] {
+    return [
+      ("testPerformance",testPerformance),
+      ("testPerformanceCluster",testPerformanceCluster),
+      ("testPerformanceImmutable",testPerformanceImmutable)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/ToObjectTests.swift
+++ b/Tests/ObjectMapperTests/ToObjectTests.swift
@@ -205,3 +205,18 @@ class ToObjectTests: XCTestCase {
 	}
 }
 
+#if os(Linux)
+extension ToObjectTests {
+  static var allTests : [(String, (ToObjectTests) -> () throws -> Void)] {
+    return [
+      ("testMappingPersonFromJSON",testMappingPersonFromJSON),
+      ("testUpdatingChildObject",testUpdatingChildObject),
+      ("testUpdatingChildDictionary",testUpdatingChildDictionary),
+      ("testToObjectFromString",testToObjectFromString),
+      ("testToObjectFromJSON",testToObjectFromJSON),
+      ("testToObjectFromAny",testToObjectFromAny),
+      ("testConsume",testConsume)
+    ]
+  }
+}
+#endif

--- a/Tests/ObjectMapperTests/URLTransformTests.swift
+++ b/Tests/ObjectMapperTests/URLTransformTests.swift
@@ -29,3 +29,14 @@ class URLTransformTests: XCTestCase {
         XCTAssertEqual(output, URL(string: "https://example.com/%25"))
     }
 }
+
+#if os(Linux)
+extension URLTransformTests {
+  static var allTests : [(String, (URLTransformTests) -> () throws -> Void)] {
+    return [
+      ("testUrlQueryAllowed",testUrlQueryAllowed),
+      ("testCanPassInAllowedCharacterSet",testCanPassInAllowedCharacterSet)
+    ]
+  }
+}
+#endif


### PR DESCRIPTION
Started PR to support Swift projects using this library on Linux. 
Main issues this PR solves:

- Initial compilation issues when running `swift test`
- Added required structure for tests to run under Linux. (`LinuxMain.swift` and `allTests` method)
- Tests that depend on UIKit won't run for Linux since there is no support for that yet.
- [5f372d0](https://github.com/redsift/ObjectMapper/commit/5f372d0ff7dc3b7210e1000373077f535557d7ea) fixes parsing from JSON for Ints which was always evaluating to nil.

With this PR at least all tests are able to run and the many issues that exist on Linux can be detected faster.

TODO list (not exhaustive):

- few tests (6 or 7) throw compilation errors and have been commented out from the `allTests` method
- fix parsing of Float `to` and `from` JSON
- fix parsing of Double `to` and `from` JSON (precision issues)