### PR TITLE
unifying default args of and simplifying map subscripts

### DIFF
--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -62,52 +62,54 @@ public final class Map {
 	/// The Key paramater can be a period separated string (ex. "distance.value") to access sub objects.
 	public subscript(key: String) -> Map {
 		// save key and value associated to it
-		return self[key, delimiter: ".", ignoreNil: false]
+		return self.subscript(key: key)
 	}
 	
 	public subscript(key: String, delimiter delimiter: String) -> Map {
-		let nested = key.contains(delimiter)
-		return self[key, nested: nested, delimiter: delimiter, ignoreNil: false]
+		return self.subscript(key: key, delimiter: delimiter)
 	}
 	
 	public subscript(key: String, nested nested: Bool) -> Map {
-		return self[key, nested: nested, delimiter: ".", ignoreNil: false]
+		return self.subscript(key: key, nested: nested)
 	}
 	
 	public subscript(key: String, nested nested: Bool, delimiter delimiter: String) -> Map {
-		return self[key, nested: nested, delimiter: delimiter, ignoreNil: false]
+		return self.subscript(key: key, nested: nested, delimiter: delimiter)
 	}
 	
 	public subscript(key: String, ignoreNil ignoreNil: Bool) -> Map {
-		return self[key, delimiter: ".", ignoreNil: ignoreNil]
+		return self.subscript(key: key, ignoreNil: ignoreNil)
 	}
 	
 	public subscript(key: String, delimiter delimiter: String, ignoreNil ignoreNil: Bool) -> Map {
-		let nested = key.contains(delimiter)
-		return self[key, nested: nested, delimiter: delimiter, ignoreNil: ignoreNil]
+		return self.subscript(key: key, delimiter: delimiter, ignoreNil: ignoreNil)
 	}
 	
 	public subscript(key: String, nested nested: Bool, ignoreNil ignoreNil: Bool) -> Map {
-		return self[key, nested: nested, delimiter: ".", ignoreNil: ignoreNil]
+		return self.subscript(key: key, nested: nested, ignoreNil: ignoreNil)
 	}
 	
-	public subscript(key: String, nested nested: Bool, delimiter delimiter: String, ignoreNil ignoreNil: Bool) -> Map {
+	public subscript(key: String, nested nested: Bool?, delimiter delimiter: String, ignoreNil ignoreNil: Bool) -> Map {
+		return self.subscript(key: key, nested: nested, delimiter: delimiter, ignoreNil: ignoreNil)
+	}
+	
+	private func `subscript`(key: String, nested: Bool? = nil, delimiter: String = ".", ignoreNil: Bool = false) -> Map {
 		// save key and value associated to it
 		currentKey = key
-		keyIsNested = nested
+		keyIsNested = nested ?? key.contains(delimiter)
 		nestedKeyDelimiter = delimiter
 		
 		if mappingType == .fromJSON {
 			// check if a value exists for the current key
 			// do this pre-check for performance reasons
-			if nested == false {
+			if keyIsNested {
+				// break down the components of the key that are separated by delimiter
+				(isKeyPresent, currentValue) = valueFor(ArraySlice(key.components(separatedBy: delimiter)), dictionary: JSON)
+			} else {
 				let object = JSON[key]
 				let isNSNull = object is NSNull
 				isKeyPresent = isNSNull ? true : object != nil
 				currentValue = isNSNull ? nil : object
-			} else {
-				// break down the components of the key that are separated by .
-				(isKeyPresent, currentValue) = valueFor(ArraySlice(key.components(separatedBy: delimiter)), dictionary: JSON)
 			}
 			
 			// update isKeyPresent if ignoreNil is true


### PR DESCRIPTION
Hi!

This is just a small and simple change to unify default arguments for subscripts by using a common private function. Default arguments are now defined in one place - in this common function instead of being scattered among different subscripts.

This also simplifies subscripts to just call the underlying common function so that there is no additional logic in a subscript itself (like it was in a case of a nested parameter: `let nested = key.contains(delimiter)`).