### PR TITLE
Use swift version DSL

### DIFF
--- a/ObjectMapper.podspec
+++ b/ObjectMapper.podspec
@@ -12,10 +12,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
 
-
-  s.pod_target_xcconfig = {
-    'SWIFT_VERSION' => '4.0',
-  }
+  s.swift_version = '4.0'
 
   s.requires_arc = true
   s.source_files = 'Sources/**/*.swift'


### PR DESCRIPTION
Since CocoaPod 1.4.0 a new property has been introduced which sets the correct swift version in a project. That means that CocoaPod is now handling what ever has to be done in the project to set the correct compiler version.

Maybe at some point you may want to create a version including this new property :)