### PR TITLE
Issue with parsing Floats in Swift 4.1 

### DIFF
--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -122,6 +122,7 @@ public final class Map {
 	public func value<T>() -> T? {
 		let value = currentValue as? T
 		
+		// Swift 4.1 breaks Float casting from `NSNumber`. So Added extra checks for `Flaot` `[Float]` and `[String:Float]`
 		if value == nil && T.self == Float.self {
 			if let v = currentValue as? NSNumber {
 				return v.floatValue as? T

--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -120,9 +120,23 @@ public final class Map {
 	}
 	
 	public func value<T>() -> T? {
-		return currentValue as? T
+		let value = currentValue as? T
+		
+		if value == nil && T.self == Float.self {
+			if let v = currentValue as? NSNumber {
+				return v.floatValue as? T
+			}
+		} else if value == nil && T.self == [Float].self {
+			if let v = currentValue as? [Double] {
+				return v.compactMap{ Float($0) } as? T
+			}
+		} else if value == nil && T.self == [String:Float].self {
+			if let v = currentValue as? [String:Double] {
+				return v.mapValues{ Float($0) } as? T
+			}
+		}
+		return value
 	}
-	
 }
 
 /// Fetch value from JSON dictionary, loop through keyPathComponents until we reach the desired object

--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -129,7 +129,7 @@ public final class Map {
 			}
 		} else if value == nil && T.self == [Float].self {
 			if let v = currentValue as? [Double] {
-				return v.compactMap{ Float($0) } as? T
+				return v.flatMap{ Float($0) } as? T
 			}
 		} else if value == nil && T.self == [String:Float].self {
 			if let v = currentValue as? [String:Double] {


### PR DESCRIPTION
Swift 4.1 breaks the Float parsing, ObjectMapper test cases were getting failed for floats. 
Issue is happening for the following data types 
1. Float
2. [Float] 
3. [String:Float]
