### PR TITLE
Honor shouldIncludeNilValues for optionalObjects

### DIFF
--- a/Sources/ToJSON.swift
+++ b/Sources/ToJSON.swift
@@ -98,7 +98,7 @@ internal final class ToJSON {
 		if let field = field {
 			basicType(field, map: map)
 		} else if map.shouldIncludeNilValues {
-			basicType(NSNull(), map: map)  //If BasicType is nil, emil NSNull into the JSON output
+			basicType(NSNull(), map: map)  //If BasicType is nil, emit NSNull into the JSON output
 		}
 	}
 
@@ -111,6 +111,8 @@ internal final class ToJSON {
 	class func optionalObject<N: BaseMappable>(_ field: N?, map: Map) {
 		if let field = field {
 			object(field, map: map)
+		} else if map.shouldIncludeNilValues {
+			basicType(NSNull(), map: map)  //If field is nil, emit NSNull into the JSON output
 		}
 	}
 


### PR DESCRIPTION
As described #956 nested optional Objects which are received as null are not serialized back as null since shouldIncludeNilValues is not honored.
Fixed by doing the same as for a basic field.