### PR TITLE
Swift 4.2 Compatibility

### DIFF
--- a/Sources/EnumOperators.swift
+++ b/Sources/EnumOperators.swift
@@ -31,11 +31,6 @@ public func >>> <T: RawRepresentable>(left: T?, right: Map) {
 }
 
 
-/// Implicitly Unwrapped Optional Object of Raw Representable type
-public func <- <T: RawRepresentable>(left: inout T!, right: Map) {
-	left <- (right, EnumTransform())
-}
-
 // MARK:- Arrays of Raw Representable type
 
 /// Array of Raw Representable object
@@ -58,11 +53,6 @@ public func >>> <T: RawRepresentable>(left: [T]?, right: Map) {
 }
 
 
-/// Array of Raw Representable object
-public func <- <T: RawRepresentable>(left: inout [T]!, right: Map) {
-	left <- (right, EnumTransform())
-}
-
 // MARK:- Dictionaries of Raw Representable type
 
 /// Dictionary of Raw Representable object
@@ -82,10 +72,4 @@ public func <- <T: RawRepresentable>(left: inout [String: T]?, right: Map) {
 
 public func >>> <T: RawRepresentable>(left: [String: T]?, right: Map) {
 	left >>> (right, EnumTransform())
-}
-
-
-/// Dictionary of Raw Representable object
-public func <- <T: RawRepresentable>(left: inout [String: T]!, right: Map) {
-	left <- (right, EnumTransform())
 }

--- a/Sources/FromJSON.swift
+++ b/Sources/FromJSON.swift
@@ -40,11 +40,6 @@ internal final class FromJSON {
 		field = object
 	}
 	
-	/// Implicitly unwrapped optional basic type
-	class func optionalBasicType<FieldType>(_ field: inout FieldType!, object: FieldType?) {
-		field = object
-	}
-	
 	/// Mappable object
 	class func object<N: BaseMappable>(_ field: inout N, map: Map) {
 		if map.toObject {
@@ -59,15 +54,6 @@ internal final class FromJSON {
 	class func optionalObject<N: BaseMappable>(_ field: inout N?, map: Map) {
 		if let f = field , map.toObject && map.currentValue != nil {
 			 field = Mapper(context: map.context).map(JSONObject: map.currentValue, toObject: f)
-		} else {
-			field = Mapper(context: map.context).map(JSONObject: map.currentValue)
-		}
-	}
-	
-	/// Implicitly unwrapped Optional Mappable Object
-	class func optionalObject<N: BaseMappable>(_ field: inout N!, map: Map) {
-		if let f = field , map.toObject && map.currentValue != nil {
-			field = Mapper(context: map.context).map(JSONObject: map.currentValue, toObject: f)
 		} else {
 			field = Mapper(context: map.context).map(JSONObject: map.currentValue)
 		}
@@ -90,15 +76,6 @@ internal final class FromJSON {
 		}
 	}
 	
-	/// Implicitly unwrapped optional mappable object array
-	class func optionalObjectArray<N: BaseMappable>(_ field: inout Array<N>!, map: Map) {
-		if let objects: Array<N> = Mapper(context: map.context).mapArray(JSONObject: map.currentValue) {
-			field = objects
-		} else {
-			field = nil
-		}
-	}
-	
 	/// mappable object array
 	class func twoDimensionalObjectArray<N: BaseMappable>(_ field: inout Array<Array<N>>, map: Map) {
 		if let objects = Mapper<N>(context: map.context).mapArrayOfArrays(JSONObject: map.currentValue) {
@@ -108,11 +85,6 @@ internal final class FromJSON {
 	
 	/// optional mappable 2 dimentional object array
 	class func optionalTwoDimensionalObjectArray<N: BaseMappable>(_ field: inout Array<Array<N>>?, map: Map) {
-		field = Mapper(context: map.context).mapArrayOfArrays(JSONObject: map.currentValue)
-	}
-	
-	/// Implicitly unwrapped optional 2 dimentional mappable object array
-	class func optionalTwoDimensionalObjectArray<N: BaseMappable>(_ field: inout Array<Array<N>>!, map: Map) {
 		field = Mapper(context: map.context).mapArrayOfArrays(JSONObject: map.currentValue)
 	}
 	
@@ -136,15 +108,6 @@ internal final class FromJSON {
 		}
 	}
 	
-	/// Implicitly unwrapped Dictionary containing Mappable objects
-	class func optionalObjectDictionary<N: BaseMappable>(_ field: inout Dictionary<String, N>!, map: Map) {
-		if let f = field , map.toObject && map.currentValue != nil {
-			field = Mapper(context: map.context).mapDictionary(JSONObject: map.currentValue, toDictionary: f)
-		} else {
-			field = Mapper(context: map.context).mapDictionary(JSONObject: map.currentValue)
-		}
-	}
-	
 	/// Dictionary containing Array of Mappable objects
 	class func objectDictionaryOfArrays<N: BaseMappable>(_ field: inout Dictionary<String, [N]>, map: Map) {
 		if let objects = Mapper<N>(context: map.context).mapDictionaryOfArrays(JSONObject: map.currentValue) {
@@ -154,11 +117,6 @@ internal final class FromJSON {
 	
 	/// Optional Dictionary containing Array of Mappable objects
 	class func optionalObjectDictionaryOfArrays<N: BaseMappable>(_ field: inout Dictionary<String, [N]>?, map: Map) {
-		field = Mapper<N>(context: map.context).mapDictionaryOfArrays(JSONObject: map.currentValue)
-	}
-	
-	/// Implicitly unwrapped Dictionary containing Array of Mappable objects
-	class func optionalObjectDictionaryOfArrays<N: BaseMappable>(_ field: inout Dictionary<String, [N]>!, map: Map) {
 		field = Mapper<N>(context: map.context).mapDictionaryOfArrays(JSONObject: map.currentValue)
 	}
 	
@@ -173,9 +131,4 @@ internal final class FromJSON {
 	class func optionalObjectSet<N: BaseMappable>(_ field: inout Set<N>?, map: Map) {
 		field = Mapper(context: map.context).mapSet(JSONObject: map.currentValue)
 	}
-	
-	/// Implicitly unwrapped optional mappable object array
-	class func optionalObjectSet<N: BaseMappable>(_ field: inout Set<N>!, map: Map) {
-		field = Mapper(context: map.context).mapSet(JSONObject: map.currentValue)
-	}	
 }

--- a/Sources/IntegerOperators.swift
+++ b/Sources/IntegerOperators.swift
@@ -34,18 +34,6 @@ public func <- <T: SignedInteger>(left: inout T?, right: Map) {
 	}
 }
 
-/// ImplicitlyUnwrappedOptional SignedInteger mapping
-public func <- <T: SignedInteger>(left: inout T!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		let value: T! = toSignedInteger(right.currentValue)
-		FromJSON.basicType(&left, object: value)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
-
 
 // MARK: - Unsigned Integer
 
@@ -67,18 +55,6 @@ public func <- <T: UnsignedInteger>(left: inout T?, right: Map) {
 	switch right.mappingType {
 	case .fromJSON where right.isKeyPresent:
 		let value: T? = toUnsignedInteger(right.currentValue)
-		FromJSON.basicType(&left, object: value)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
-
-/// ImplicitlyUnwrappedOptional UnsignedInteger mapping
-public func <- <T: UnsignedInteger>(left: inout T!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		let value: T! = toUnsignedInteger(right.currentValue)
 		FromJSON.basicType(&left, object: value)
 	case .toJSON:
 		left >>> right

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -75,18 +75,6 @@ public func >>> <T>(left: T?, right: Map) {
 	}
 }
 
-
-/// Implicitly unwrapped optional object of basic type
-public func <- <T>(left: inout T!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalBasicType(&left, object: right.value())
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
-
 // MARK:- Mappable Objects - <T: BaseMappable>
 
 /// Object conforming to Mappable
@@ -120,18 +108,6 @@ public func <- <T: BaseMappable>(left: inout T?, right: Map) {
 public func >>> <T: BaseMappable>(left: T?, right: Map) {
 	if right.mappingType == .toJSON {
 		ToJSON.optionalObject(left, map: right)
-	}
-}
-
-
-/// Implicitly unwrapped optional Mappable objects
-public func <- <T: BaseMappable>(left: inout T!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalObject(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
 	}
 }
 
@@ -172,18 +148,6 @@ public func >>> <T: BaseMappable>(left: Dictionary<String, T>?, right: Map) {
 	}
 }
 
-
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: BaseMappable>(left: inout Dictionary<String, T>!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalObjectDictionary(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
-
 /// Dictionary of Mappable objects <String, T: Mappable>
 public func <- <T: BaseMappable>(left: inout Dictionary<String, [T]>, right: Map) {
 	switch right.mappingType {
@@ -215,18 +179,6 @@ public func <- <T: BaseMappable>(left: inout Dictionary<String, [T]>?, right: Ma
 public func >>> <T: BaseMappable>(left: Dictionary<String, [T]>?, right: Map) {
 	if right.mappingType == .toJSON {
 		ToJSON.optionalObjectDictionaryOfArrays(left, map: right)
-	}
-}
-
-
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: BaseMappable>(left: inout Dictionary<String, [T]>!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalObjectDictionaryOfArrays(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
 	}
 }
 
@@ -263,18 +215,6 @@ public func <- <T: BaseMappable>(left: inout Array<T>?, right: Map) {
 public func >>> <T: BaseMappable>(left: Array<T>?, right: Map) {
 	if right.mappingType == .toJSON {
 		ToJSON.optionalObjectArray(left, map: right)
-	}
-}
-
-
-/// Implicitly unwrapped Optional array of Mappable objects
-public func <- <T: BaseMappable>(left: inout Array<T>!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalObjectArray(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
 	}
 }
 
@@ -315,18 +255,6 @@ public func >>> <T: BaseMappable>(left: Array<Array<T>>?, right: Map) {
 	}
 }
 
-
-/// Implicitly unwrapped Optional array of Mappable objects
-public func <- <T: BaseMappable>(left: inout Array<Array<T>>!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalTwoDimensionalObjectArray(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
-
 // MARK:- Set of Mappable objects - Set<T: BaseMappable>
 
 /// Set of Mappable objects
@@ -361,17 +289,5 @@ public func <- <T: BaseMappable>(left: inout Set<T>?, right: Map) {
 public func >>> <T: BaseMappable>(left: Set<T>?, right: Map) {
 	if right.mappingType == .toJSON {
 		ToJSON.optionalObjectSet(left, map: right)
-	}
-}
-
-
-/// Implicitly unwrapped Optional Set of Mappable objects
-public func <- <T: BaseMappable>(left: inout Set<T>!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalObjectSet(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
 	}
 }

--- a/Sources/TransformOperators.swift
+++ b/Sources/TransformOperators.swift
@@ -53,20 +53,6 @@ public func >>> <Transform: TransformType>(left: Transform.Object?, right: (Map,
 	}
 }
 
-
-/// Implicitly unwrapped optional object of basic type with Transform
-public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (Map, Transform)) {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		let value = transform.transformFromJSON(map.currentValue)
-		FromJSON.optionalBasicType(&left, object: value)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
-
 /// Array of Basic type with Transform
 public func <- <Transform: TransformType>(left: inout [Transform.Object], right: (Map, Transform)) {
 	let (map, transform) = right
@@ -110,20 +96,6 @@ public func >>> <Transform: TransformType>(left: [Transform.Object]?, right: (Ma
 	}
 }
 
-
-/// Implicitly unwrapped optional array of Basic type with Transform
-public func <- <Transform: TransformType>(left: inout [Transform.Object]!, right: (Map, Transform)) {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		let values = fromJSONArrayWithTransform(map.currentValue, transform: transform)
-		FromJSON.optionalBasicType(&left, object: values)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
-
 /// Dictionary of Basic type with Transform
 public func <- <Transform: TransformType>(left: inout [String: Transform.Object], right: (Map, Transform)) {
 	let (map, transform) = right
@@ -164,20 +136,6 @@ public func >>> <Transform: TransformType>(left: [String: Transform.Object]?, ri
 	if map.mappingType == .toJSON {
 		let values = toJSONDictionaryWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(values, map: map)
-	}
-}
-
-
-/// Implicitly unwrapped optional dictionary of Basic type with Transform
-public func <- <Transform: TransformType>(left: inout [String: Transform.Object]!, right: (Map, Transform)) {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		let values = fromJSONDictionaryWithTransform(map.currentValue, transform: transform)
-		FromJSON.optionalBasicType(&left, object: values)
-	case .toJSON:
-		left >>> right
-	default: ()
 	}
 }
 
@@ -227,20 +185,6 @@ public func >>> <Transform: TransformType>(left: Transform.Object?, right: (Map,
 }
 
 
-/// Implicitly unwrapped optional Mappable objects that have transforms
-public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (Map, Transform)) where Transform.Object: BaseMappable {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		let value: Transform.Object? = transform.transformFromJSON(map.currentValue)
-		FromJSON.optionalBasicType(&left, object: value)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
-
-
 // MARK:- Dictionary of Mappable objects with a transform - Dictionary<String, T: BaseMappable>
 
 /// Dictionary of Mappable objects <String, T: Mappable> with a transform
@@ -280,18 +224,6 @@ public func >>> <Transform: TransformType>(left: Dictionary<String, Transform.Ob
 	if map.mappingType == .toJSON {
 		let value = toJSONDictionaryWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(value, map: map)
-	}
-}
-
-
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType>(left: inout Dictionary<String, Transform.Object>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
-	let (map, transform) = right
-	if map.mappingType == .fromJSON && map.isKeyPresent, let dictionary = map.currentValue as? [String : Any]{
-		let transformedDictionary = fromJSONDictionaryWithTransform(dictionary as Any?, transform: transform) ?? left
-		FromJSON.optionalBasicType(&left, object: transformedDictionary)
-	} else if map.mappingType == .toJSON {
-		left >>> right
 	}
 }
 
@@ -366,28 +298,6 @@ public func >>> <Transform: TransformType>(left: Dictionary<String, [Transform.O
 	}
 }
 
-
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType>(left: inout Dictionary<String, [Transform.Object]>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
-	let (map, transform) = right
-	
-	if let dictionary = map.currentValue as? [String : [Any]], map.mappingType == .fromJSON && map.isKeyPresent {
-		let transformedDictionary = dictionary.map { (arg: (key: String, values: [Any])) -> (String, [Transform.Object]) in
-			let (key, values) = arg
-			if let jsonArray = fromJSONArrayWithTransform(values, transform: transform) {
-				return (key, jsonArray)
-			}
-			if let leftValue = left?[key] {
-				return (key, leftValue)
-			}
-			return (key, [])
-		}
-		FromJSON.optionalBasicType(&left, object: transformedDictionary)
-	} else if map.mappingType == .toJSON {
-		left >>> right
-	}
-}
-
 // MARK:- Array of Mappable objects with transforms - Array<T: BaseMappable>
 
 /// Array of Mappable objects
@@ -431,20 +341,6 @@ public func >>> <Transform: TransformType>(left: Array<Transform.Object>?, right
 	if map.mappingType == .toJSON {
 		let transformedValues = toJSONArrayWithTransform(left, transform: transform)
 		ToJSON.optionalBasicType(transformedValues, map: map)
-	}
-}
-
-
-/// Implicitly unwrapped Optional array of Mappable objects
-public func <- <Transform: TransformType>(left: inout Array<Transform.Object>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform)
-		FromJSON.optionalBasicType(&left, object: transformedValues)
-	case .toJSON:
-		left >>> right
-	default: ()
 	}
 }
 
@@ -504,24 +400,6 @@ public func >>> <Transform: TransformType>(left: [[Transform.Object]]?, right: (
 	}
 }
 
-
-/// Implicitly unwrapped Optional array of array of objects with transform
-public func <- <Transform: TransformType>(left: inout [[Transform.Object]]!, right: (Map, Transform)) {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .toJSON:
-		left >>> right
-	case .fromJSON where map.isKeyPresent:
-		guard let original2DArray = map.currentValue as? [[Any]] else { break }
-		let transformed2DArray = original2DArray.compactMap { values in
-			fromJSONArrayWithTransform(values as Any?, transform: transform)
-		}
-		FromJSON.optionalBasicType(&left, object: transformed2DArray)
-	default:
-		break
-	}
-}
-
 // MARK:- Set of Mappable objects with a transform - Set<T: BaseMappable>
 
 /// Set of Mappable objects with transform
@@ -568,21 +446,6 @@ public func >>> <Transform: TransformType>(left: Set<Transform.Object>?, right: 
 			let transformedValues = toJSONArrayWithTransform(Array(values), transform: transform)
 			ToJSON.optionalBasicType(transformedValues, map: map)
 		}
-	}
-}
-
-
-/// Implicitly unwrapped Optional set of Mappable objects with transform
-public func <- <Transform: TransformType>(left: inout Set<Transform.Object>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		if let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform) {
-			FromJSON.basicType(&left, object: Set(transformedValues))
-		}
-	case .toJSON:
-		left >>> right
-	default: ()
 	}
 }
 


### PR DESCRIPTION
Swift 4.2 Proposal 0054: Abolish ImplicitlyUnwrappedOptional type

This commit and branch will introduce support for Swift 4.2, first available in the Xcode 10 Beta build.

ObjectMapper becomes unusable due to a wide number of "Invalid Redeclaration" errors.

These errors occurred due to the fact that many functions were copied and pasted to support Optional values as well as implicitly unwrapped optional values.

As of Swift 4.2, and due to Swift Evolution SE0054 proposal (Abolish ImplicitlyUnwrappedOptional type), this redeclaration is no longer necessary.

Please refer to WWDC's 2018 "What's New in Swift" video at https://developer.apple.com/videos/play/wwdc2018/401/

Swift Evolution SE0054:
https://github.com/apple/swift-evolution/blob/master/proposals/0054-abolish-iuo.md