### PR TITLE
Add transform class for Codable types

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -23,6 +23,13 @@
 		3BAD2C0E1BDDB10D00E6B203 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */; };
 		3BAD2C101BDDC0B000E6B203 /* MappableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */; };
 		3BAD2C111BDDC0B000E6B203 /* MappableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */; };
+		491D7995216FB8B2006DB931 /* CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D7994216FB8B2006DB931 /* CodableTests.swift */; };
+		491D7996216FB8B2006DB931 /* CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D7994216FB8B2006DB931 /* CodableTests.swift */; };
+		491D7997216FB8B2006DB931 /* CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D7994216FB8B2006DB931 /* CodableTests.swift */; };
+		491D799C216FBA9A006DB931 /* CodableTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D7998216FBA93006DB931 /* CodableTransform.swift */; };
+		491D799D216FBA9A006DB931 /* CodableTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D7998216FBA93006DB931 /* CodableTransform.swift */; };
+		491D799E216FBA9B006DB931 /* CodableTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D7998216FBA93006DB931 /* CodableTransform.swift */; };
+		491D799F216FBA9B006DB931 /* CodableTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D7998216FBA93006DB931 /* CodableTransform.swift */; };
 		6100B1C01BD76A030011114A /* NestedArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6100B1BF1BD76A020011114A /* NestedArrayTests.swift */; };
 		6A05B7B01BE274BE00F19B53 /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A05B7A61BE274BE00F19B53 /* ObjectMapper.framework */; };
 		6A05B7BD1BE274E800F19B53 /* ObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AAC8F7B19F03C2900E7A677 /* ObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -227,6 +234,8 @@
 		37AFD9B81AAD191C00AB59B5 /* CustomDateFormatTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomDateFormatTransform.swift; sourceTree = "<group>"; };
 		3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Mappable.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		3BAD2C0F1BDDC0B000E6B203 /* MappableExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MappableExtensionsTests.swift; path = ObjectMapperTests/MappableExtensionsTests.swift; sourceTree = "<group>"; };
+		491D7994216FB8B2006DB931 /* CodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CodableTests.swift; path = ObjectMapperTests/CodableTests.swift; sourceTree = "<group>"; };
+		491D7998216FBA93006DB931 /* CodableTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodableTransform.swift; sourceTree = "<group>"; };
 		6100B1BF1BD76A020011114A /* NestedArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = NestedArrayTests.swift; path = ObjectMapperTests/NestedArrayTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6A05B7A61BE274BE00F19B53 /* ObjectMapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectMapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A05B7AF1BE274BE00F19B53 /* ObjectMapper-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ObjectMapper-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -392,6 +401,7 @@
 		6AAC8F8219F03C2900E7A677 /* ObjectMapperTests */ = {
 			isa = PBXGroup;
 			children = (
+				491D7994216FB8B2006DB931 /* CodableTests.swift */,
 				6A6AEB971A9387D0002573D3 /* BasicTypes.swift */,
 				6A3774331A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift */,
 				6A6AEB951A93874F002573D3 /* BasicTypesTestsFromJSON.swift */,
@@ -455,6 +465,7 @@
 				997B4A461D3FA20D005E3F31 /* DictionaryTransform.swift */,
 				C135CAB31D762F6900BA9338 /* DataTransform.swift */,
 				79E591C61DAB7FED008E2EEF /* HexColorTransform.swift */,
+				491D7998216FBA93006DB931 /* CodableTransform.swift */,
 			);
 			name = Transforms;
 			sourceTree = "<group>";
@@ -770,6 +781,7 @@
 				6AC6923A1BE3FD3A004C119A /* DateFormatterTransform.swift in Sources */,
 				6AC6923B1BE3FD3A004C119A /* ISO8601DateTransform.swift in Sources */,
 				6AC6923C1BE3FD3A004C119A /* CustomDateFormatTransform.swift in Sources */,
+				491D799F216FBA9B006DB931 /* CodableTransform.swift in Sources */,
 				6AC6923D1BE3FD3A004C119A /* TransformOf.swift in Sources */,
 				6AC6923E1BE3FD3A004C119A /* TransformType.swift in Sources */,
 				6AC6923F1BE3FD3A004C119A /* URLTransform.swift in Sources */,
@@ -793,6 +805,7 @@
 				6AA1F66B1BE94687006EF513 /* ClassClusterTests.swift in Sources */,
 				6AECC9E81D79E29100222E7A /* DictionaryTransformTests.swift in Sources */,
 				6AA1F66C1BE94687006EF513 /* PerformanceTests.swift in Sources */,
+				491D7997216FB8B2006DB931 /* CodableTests.swift in Sources */,
 				6AC692411BE3FD45004C119A /* BasicTypes.swift in Sources */,
 				6A0BF2011C0B53470083D1AF /* ToObjectTests.swift in Sources */,
 				84D4F8591CC3B71B008B0FB6 /* NSDecimalNumberTransformTests.swift in Sources */,
@@ -827,6 +840,7 @@
 				6A2AD04A1B2C786C0097E150 /* DateFormatterTransform.swift in Sources */,
 				6A2AD04B1B2C786C0097E150 /* ISO8601DateTransform.swift in Sources */,
 				6A2AD04C1B2C786C0097E150 /* CustomDateFormatTransform.swift in Sources */,
+				491D799E216FBA9B006DB931 /* CodableTransform.swift in Sources */,
 				6A2AD04D1B2C786C0097E150 /* TransformOf.swift in Sources */,
 				6A2AD04E1B2C786C0097E150 /* TransformType.swift in Sources */,
 				6A2AD04F1B2C786C0097E150 /* URLTransform.swift in Sources */,
@@ -857,6 +871,7 @@
 				CD71C8C11A7218AD009D4161 /* TransformOf.swift in Sources */,
 				6A6C54D019FE8DB600239454 /* URLTransform.swift in Sources */,
 				038F0A031E55FE2400613148 /* IntegerOperators.swift in Sources */,
+				491D799C216FBA9A006DB931 /* CodableTransform.swift in Sources */,
 				6A51372C1AADDE2700B82516 /* DateFormatterTransform.swift in Sources */,
 				6AAC8FCE19F048FE00E7A677 /* Mapper.swift in Sources */,
 				6AAC8FCD19F048FE00E7A677 /* FromJSON.swift in Sources */,
@@ -882,6 +897,7 @@
 				6AECC9E61D79E29100222E7A /* DictionaryTransformTests.swift in Sources */,
 				6A0BF1FF1C0B53470083D1AF /* ToObjectTests.swift in Sources */,
 				CD44374D1AAE9C1100A271BA /* NestedKeysTests.swift in Sources */,
+				491D7995216FB8B2006DB931 /* CodableTests.swift in Sources */,
 				6A3774341A31427F00CC0AB5 /* BasicTypesTestsToJSON.swift in Sources */,
 				84D4F8571CC3B71B008B0FB6 /* NSDecimalNumberTransformTests.swift in Sources */,
 				6A412A171BAC770C001C3F67 /* ClassClusterTests.swift in Sources */,
@@ -915,6 +931,7 @@
 				CD16031F1AC02461000CD69A /* ISO8601DateTransform.swift in Sources */,
 				CD1603211AC02472000CD69A /* TransformOf.swift in Sources */,
 				CD1603231AC02472000CD69A /* URLTransform.swift in Sources */,
+				491D799D216FBA9A006DB931 /* CodableTransform.swift in Sources */,
 				CD16031C1AC02451000CD69A /* ToJSON.swift in Sources */,
 				CD16031D1AC02461000CD69A /* DateTransform.swift in Sources */,
 				CD1603191AC02451000CD69A /* Mapper.swift in Sources */,
@@ -938,6 +955,7 @@
 				6AA1F66D1BE9468D006EF513 /* NestedArrayTests.swift in Sources */,
 				6AECC9E71D79E29100222E7A /* DictionaryTransformTests.swift in Sources */,
 				6A412A181BAC830B001C3F67 /* ClassClusterTests.swift in Sources */,
+				491D7996216FB8B2006DB931 /* CodableTests.swift in Sources */,
 				CD1603261AC02480000CD69A /* BasicTypesTestsFromJSON.swift in Sources */,
 				6A0BF2001C0B53470083D1AF /* ToObjectTests.swift in Sources */,
 				84D4F8581CC3B71B008B0FB6 /* NSDecimalNumberTransformTests.swift in Sources */,

--- a/Sources/CodableTransform.swift
+++ b/Sources/CodableTransform.swift
@@ -1,0 +1,65 @@
+//
+//  CodableTransform.swift
+//  ObjectMapper
+//
+//  Created by Jari Kalinainen on 10/10/2018.
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2014-2016 Hearst
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// Transforms JSON dictionary to Codable type T and back
+open class CodableTransform<T: Codable>: TransformType {
+
+    public typealias Object = T
+    public typealias JSON = Any
+
+    public init() {}
+
+    open func transformFromJSON(_ value: Any?) -> Object? {
+        guard let dict = value as? [String: Any], let data = try? JSONSerialization.data(withJSONObject: dict, options: []) else {
+            return nil
+        }
+        do {
+            let decoder = JSONDecoder()
+            let item = try decoder.decode(T.self, from: data)
+            return item
+        } catch {
+            return nil
+        }
+    }
+
+    open func transformToJSON(_ value: T?) -> JSON? {
+        guard let item = value else {
+            return nil
+        }
+        do {
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(item)
+            let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
+            return dictionary
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Tests/ObjectMapperTests/CodableTests.swift
+++ b/Tests/ObjectMapperTests/CodableTests.swift
@@ -1,0 +1,81 @@
+//
+//  CodableTests.swift
+//  ObjectMapper
+//
+//  Created by Jari Kalinainen on 11.10.18.
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2014-2016 Hearst
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+import XCTest
+import ObjectMapper
+
+class CodableTests: XCTestCase {
+	
+	override func setUp() {
+		super.setUp()
+		// Put setup code here. This method is called before the invocation of each test method in the class.
+	}
+	
+	override func tearDown() {
+		// Put teardown code here. This method is called after the invocation of each test method in the class.
+		super.tearDown()
+	}
+	
+	func testCodableTransform() {
+		let JSON: [String: Any] = [ "value": [ "one": "1", "two": 2, "three": true ]]
+		
+		let mapper = Mapper<ImmutableMappableObject>()
+		
+		let object: ImmutableMappableObject! = mapper.map(JSON: JSON)
+		XCTAssertNotNil(object)
+		XCTAssertNil(object.nilValue) // without transform this is nil
+		XCTAssertNotNil(object.value)
+		XCTAssertNotNil(object.value?.one)
+		XCTAssertNotNil(object.value?.two)
+		XCTAssertNotNil(object.value?.three)
+	}
+	
+}
+
+class ImmutableMappableObject: ImmutableMappable {
+	
+	var value: CodableModel?
+	var nilValue: CodableModel?
+	
+	required init(map: Map) throws {
+		nilValue = try? map.value("value")
+		value = try? map.value("value", using: CodableTransform<CodableModel>())
+	}
+
+	func mapping(map: Map) {
+		nilValue <- map["value"]
+		value	<- (map["value"], using: CodableTransform<CodableModel>())
+	}
+}
+
+struct CodableModel: Codable {
+	let one: String
+	let two: Int
+	let three: Bool
+}


### PR DESCRIPTION
Enables Swift built in Codable types to be used with ObjectMapper. 

Usage:
```
    required init(map: Map) throws {
        items   = try map.value("items", using: CodableTransform<CodableModel>())
    }

    func mapping(map: Map) {
        items   >>> (map["total"], CodableTransform<CodableModel>())
    }

```
