### PR TITLE
Add Support for Decimal Type

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -149,6 +149,13 @@
 		C135CABA1D7631DB00BA9338 /* DataTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C135CAB31D762F6900BA9338 /* DataTransform.swift */; };
 		C135CABB1D7631DB00BA9338 /* DataTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C135CAB31D762F6900BA9338 /* DataTransform.swift */; };
 		C135CABC1D7631DC00BA9338 /* DataTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C135CAB31D762F6900BA9338 /* DataTransform.swift */; };
+		C6D1221F259B1DA600BAEB06 /* DecimalTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D1221E259B1DA600BAEB06 /* DecimalTransform.swift */; };
+		C6D1223A259B4A4000BAEB06 /* DecimalTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D1222C259B47DD00BAEB06 /* DecimalTransformTests.swift */; };
+		C6D12241259B4A4100BAEB06 /* DecimalTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D1222C259B47DD00BAEB06 /* DecimalTransformTests.swift */; };
+		C6D12248259B4A4100BAEB06 /* DecimalTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D1222C259B47DD00BAEB06 /* DecimalTransformTests.swift */; };
+		C6D1224F259B4A5100BAEB06 /* DecimalTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D1221E259B1DA600BAEB06 /* DecimalTransform.swift */; };
+		C6D12256259B4A5100BAEB06 /* DecimalTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D1221E259B1DA600BAEB06 /* DecimalTransform.swift */; };
+		C6D1225D259B4A5200BAEB06 /* DecimalTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D1221E259B1DA600BAEB06 /* DecimalTransform.swift */; };
 		CD16030A1AC023D6000CD69A /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD1602FF1AC023D5000CD69A /* ObjectMapper.framework */; };
 		CD1603181AC02437000CD69A /* ObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AAC8F7B19F03C2900E7A677 /* ObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD1603191AC02451000CD69A /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC419F048FE00E7A677 /* Mapper.swift */; };
@@ -302,6 +309,8 @@
 		BC1E7F361ABC44C000F9B1CF /* EnumTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumTransform.swift; sourceTree = "<group>"; };
 		C135CAB31D762F6900BA9338 /* DataTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataTransform.swift; sourceTree = "<group>"; };
 		C135CAB61D76303E00BA9338 /* DataTransformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DataTransformTests.swift; path = ObjectMapperTests/DataTransformTests.swift; sourceTree = "<group>"; };
+		C6D1221E259B1DA600BAEB06 /* DecimalTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalTransform.swift; sourceTree = "<group>"; };
+		C6D1222C259B47DD00BAEB06 /* DecimalTransformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalTransformTests.swift; sourceTree = "<group>"; };
 		CD1602FF1AC023D5000CD69A /* ObjectMapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectMapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD1603091AC023D6000CD69A /* ObjectMapper-macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ObjectMapper-macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD44374C1AAE9C1100A271BA /* NestedKeysTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = NestedKeysTests.swift; path = ObjectMapperTests/NestedKeysTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -452,6 +461,7 @@
 				6100B1BF1BD76A020011114A /* NestedArrayTests.swift */,
 				CD44374C1AAE9C1100A271BA /* NestedKeysTests.swift */,
 				84D4F8561CC3B71B008B0FB6 /* NSDecimalNumberTransformTests.swift */,
+				C6D1222C259B47DD00BAEB06 /* DecimalTransformTests.swift */,
 				DC99C8CB1CA261A8005C788C /* NullableKeysFromJSONTests.swift */,
 				6AAC8F8519F03C2900E7A677 /* ObjectMapperTests.swift */,
 				6A412A231BB0DA26001C3F67 /* PerformanceTests.swift */,
@@ -495,6 +505,7 @@
 				CD50B6FC1A82518300744312 /* TransformType.swift */,
 				6A6C54CF19FE8DB600239454 /* URLTransform.swift */,
 				BC1E7F361ABC44C000F9B1CF /* EnumTransform.swift */,
+				C6D1221E259B1DA600BAEB06 /* DecimalTransform.swift */,
 				84D4F8511CC3B643008B0FB6 /* NSDecimalNumberTransform.swift */,
 				997B4A461D3FA20D005E3F31 /* DictionaryTransform.swift */,
 				C135CAB31D762F6900BA9338 /* DataTransform.swift */,
@@ -845,6 +856,7 @@
 				997B4A4A1D3FA20D005E3F31 /* DictionaryTransform.swift in Sources */,
 				6AC692381BE3FD3A004C119A /* ToJSON.swift in Sources */,
 				6AC692391BE3FD3A004C119A /* DateTransform.swift in Sources */,
+				C6D1225D259B4A5200BAEB06 /* DecimalTransform.swift in Sources */,
 				6AC6923A1BE3FD3A004C119A /* DateFormatterTransform.swift in Sources */,
 				6AC6923B1BE3FD3A004C119A /* ISO8601DateTransform.swift in Sources */,
 				6AC6923C1BE3FD3A004C119A /* CustomDateFormatTransform.swift in Sources */,
@@ -869,6 +881,7 @@
 				6AF148861D999E31002BEA2C /* GenericObjectsTests.swift in Sources */,
 				C135CAB91D76303E00BA9338 /* DataTransformTests.swift in Sources */,
 				6A442CA31CE251F100AB4F1F /* MapContextTests.swift in Sources */,
+				C6D12248259B4A4100BAEB06 /* DecimalTransformTests.swift in Sources */,
 				6AA1F66B1BE94687006EF513 /* ClassClusterTests.swift in Sources */,
 				6AECC9E81D79E29100222E7A /* DictionaryTransformTests.swift in Sources */,
 				6AA1F66C1BE94687006EF513 /* PerformanceTests.swift in Sources */,
@@ -905,6 +918,7 @@
 				997B4A491D3FA20D005E3F31 /* DictionaryTransform.swift in Sources */,
 				6A2AD0481B2C786C0097E150 /* ToJSON.swift in Sources */,
 				6A2AD0491B2C786C0097E150 /* DateTransform.swift in Sources */,
+				C6D12256259B4A5100BAEB06 /* DecimalTransform.swift in Sources */,
 				6A2AD04A1B2C786C0097E150 /* DateFormatterTransform.swift in Sources */,
 				6A2AD04B1B2C786C0097E150 /* ISO8601DateTransform.swift in Sources */,
 				6A2AD04C1B2C786C0097E150 /* CustomDateFormatTransform.swift in Sources */,
@@ -936,6 +950,7 @@
 				997B4A471D3FA20D005E3F31 /* DictionaryTransform.swift in Sources */,
 				BC1E7F371ABC44C000F9B1CF /* EnumTransform.swift in Sources */,
 				D86BDEA41A51E5AD00120819 /* ISO8601DateTransform.swift in Sources */,
+				C6D1221F259B1DA600BAEB06 /* DecimalTransform.swift in Sources */,
 				CD71C8C11A7218AD009D4161 /* TransformOf.swift in Sources */,
 				6A6C54D019FE8DB600239454 /* URLTransform.swift in Sources */,
 				038F0A031E55FE2400613148 /* IntegerOperators.swift in Sources */,
@@ -960,6 +975,7 @@
 				6AF148841D999E31002BEA2C /* GenericObjectsTests.swift in Sources */,
 				C135CAB71D76303E00BA9338 /* DataTransformTests.swift in Sources */,
 				6A442CA11CE251F100AB4F1F /* MapContextTests.swift in Sources */,
+				C6D1223A259B4A4000BAEB06 /* DecimalTransformTests.swift in Sources */,
 				6A6AEB961A93874F002573D3 /* BasicTypesTestsFromJSON.swift in Sources */,
 				1865416F1E972FA800F95A19 /* URLTransformTests.swift in Sources */,
 				6AECC9E61D79E29100222E7A /* DictionaryTransformTests.swift in Sources */,
@@ -996,6 +1012,7 @@
 				6ACB15D31BC7F1D0006C029C /* Map.swift in Sources */,
 				997B4A481D3FA20D005E3F31 /* DictionaryTransform.swift in Sources */,
 				CD1603241AC02472000CD69A /* EnumTransform.swift in Sources */,
+				C6D1224F259B4A5100BAEB06 /* DecimalTransform.swift in Sources */,
 				CD16031F1AC02461000CD69A /* ISO8601DateTransform.swift in Sources */,
 				CD1603211AC02472000CD69A /* TransformOf.swift in Sources */,
 				CD1603231AC02472000CD69A /* URLTransform.swift in Sources */,
@@ -1020,6 +1037,7 @@
 				6AF148851D999E31002BEA2C /* GenericObjectsTests.swift in Sources */,
 				C135CAB81D76303E00BA9338 /* DataTransformTests.swift in Sources */,
 				6A442CA21CE251F100AB4F1F /* MapContextTests.swift in Sources */,
+				C6D12241259B4A4100BAEB06 /* DecimalTransformTests.swift in Sources */,
 				6AA1F66D1BE9468D006EF513 /* NestedArrayTests.swift in Sources */,
 				6AECC9E71D79E29100222E7A /* DictionaryTransformTests.swift in Sources */,
 				6A412A181BAC830B001C3F67 /* ClassClusterTests.swift in Sources */,

--- a/Sources/DecimalTransform.swift
+++ b/Sources/DecimalTransform.swift
@@ -1,0 +1,49 @@
+//
+//  DecimalTransform.swift
+//  ObjectMapper
+//
+//  Created by Tristan HanleyLee on 12/29/20.
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2020 Hanley Lee
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+open class DecimalTransform: TransformType {
+	public typealias Object = Decimal
+	public typealias JSON = Decimal
+
+	public init() {}
+
+	open func transformFromJSON(_ value: Any?) -> Decimal? {
+		if let number = value as? NSNumber {
+			return Decimal(string: number.description)
+		} else if let string = value as? String {
+			return Decimal(string: string)
+		}
+		return nil
+	}
+
+	open func transformToJSON(_ value: Decimal?) -> Decimal? {
+		return value
+	}
+}

--- a/Tests/DecimalTransformTests.swift
+++ b/Tests/DecimalTransformTests.swift
@@ -1,0 +1,70 @@
+//
+//  DecimalTransformTests.swift
+//  ObjectMapper
+//
+//  Created by HanleyLee on 12/29/20.
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2020 Hanley Lee
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import XCTest
+import ObjectMapper
+
+class DecimalTransformTests: XCTestCase {
+
+	let mapper = Mapper<DecimalType>()
+
+	func testNSDecimalNumberTransform() {
+		let int: Int = 11
+		let double: Double = 11.11
+		let intString = "11"
+		let doubleString = "11.11"
+		let JSONString = "{\"double\" : \(double), \"int\" : \(int), \"intString\" : \"\(intString)\", \"doubleString\" : \"\(doubleString)\"}"
+
+		let mappedObject = mapper.map(JSONString: JSONString)
+
+		XCTAssertNotNil(mappedObject)
+		XCTAssertEqual(mappedObject?.int, Decimal(int))
+		XCTAssertEqual(mappedObject?.double, Decimal(double))
+		XCTAssertEqual(mappedObject?.intString, Decimal(string: intString))
+		XCTAssertEqual(mappedObject?.doubleString, Decimal(string: doubleString))
+	}
+}
+
+class DecimalType: Mappable {
+
+	var int: Decimal?
+	var double: Decimal?
+	var intString: Decimal?
+	var doubleString: Decimal?
+
+	init(){ }
+
+	required init?(map: Map){ }
+
+	func mapping(map: Map) {
+		int <- (map["int"], DecimalTransform())
+		double <- (map["double"], DecimalTransform())
+		intString <- (map["intString"], DecimalTransform())
+		doubleString <- (map["doubleString"], DecimalTransform())
+	}
+}


### PR DESCRIPTION
## Why <!-- Describe why you are making the change -->

For avoiding the precision loss in Swift, we want to use Decimal Type to accept data from Server side, but currently ObjectMapper don't support Decimal transform

## What <!-- Describe what changed -->

add DecimalTransform and related Tests to support Decimal Type