### PR TITLE
Update Package.swift to swift-tools-version 5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 


### PR DESCRIPTION
## Why <!-- Describe why you are making the change -->
Issue: #1147

The current Package.swift is not valid as `.macOS(.v12)` was introduced in 5.5.


## What
Changed the swift-tools-version to 5.5